### PR TITLE
chore: tag ./internal folder, except ./internal/tools

### DIFF
--- a/.github/workflows/releaseComponents.yml
+++ b/.github/workflows/releaseComponents.yml
@@ -66,10 +66,14 @@ jobs:
             --notes-start-tag ${{ env.PREVIOUS_TAG }}
       - name: Tag Go packages on GitHub
         run: |
-          folders=("./exporter" "./extension" "./pkg" "./receiver" "./connector" "./processor")
+          folders=("./exporter" "./extension" "./pkg" "./receiver" "./connector" "./processor" "./internal")
 
           for folder in "${folders[@]}"; do
               for package_folder in $folder/*/; do
+                  if [ "$package_folder" = "./internal/tools/" ]; then
+                      echo "Skipped ./internal/tools"
+                      continue
+                  fi
                   if [ -f "$package_folder/go.mod" ]; then
                       git tag ${package_folder#./}v${{ needs.release_checks.outputs.image_tag }}
                       git push origin ${package_folder#./}v${{ needs.release_checks.outputs.image_tag }}

--- a/internal/k8sconfig/go.mod
+++ b/internal/k8sconfig/go.mod
@@ -1,4 +1,4 @@
-module github.com/solarwinds/solarwinds-otel-collector-config/internal/k8sconfig
+module github.com/solarwinds/solarwinds-otel-collector-contrib/internal/k8sconfig
 
 go 1.24.2
 


### PR DESCRIPTION
#### Description
chore: tag ./internal folder, except ./internal/tools.
Doing this so that `k8sconfig` is tagged.

#### Testing
![image](https://github.com/user-attachments/assets/bae376f6-6423-44ec-ba20-c48aab400466)

