### PR TITLE
fix: #15 fix benchmark for connector

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -49,7 +49,7 @@ jobs:
         run: ${{ env.SHARED_SCRIPTS }}/build-and-test.sh
         shell: bash
       - name: Run Benchmark
-        run: go test -C connector/solarwindsentityconnector/benchmark -run=^$ -bench . > benchmark.txt
+        run: go test -C connector/solarwindsentityconnector/benchmark -run=^$ -bench . | tee benchmark.txt
         shell: bash
       - name: Upload Benchmark Log
         uses: actions/upload-artifact@v4

--- a/connector/solarwindsentityconnector/benchmark/benchmark_test.go
+++ b/connector/solarwindsentityconnector/benchmark/benchmark_test.go
@@ -91,8 +91,7 @@ func BenchmarkMetrics(b *testing.B) {
 					expectedLogsCount = int(1 - int(tc.invalidRatio))
 				}
 
-				assert.Equal(b, getLogsCount, expectedLogsCount, "Expected to receive %d logs, but got %d logs",
-					expectedLogsCount, getLogsCount)
+				assert.Equal(b, expectedLogsCount, getLogsCount)
 				sink.Reset()
 
 				b.StartTimer()
@@ -163,8 +162,7 @@ func BenchmarkLogs(b *testing.B) {
 					expectedLogsCount = int(1 - int(tc.invalidRatio))
 				}
 
-				assert.Equal(b, getLogsCount, expectedLogsCount, "Expected to receive %d logs, but got %d logs",
-					expectedLogsCount, getLogsCount)
+				assert.Equal(b, expectedLogsCount, getLogsCount)
 				sink.Reset()
 
 				b.StartTimer()


### PR DESCRIPTION
#### Description
Improve GitHub Actions pipeline for easier analysis of benchmark assertion failures. Benchmark added in previous PR: [#34](https://github.com/solarwinds/solarwinds-otel-collector-contrib/pull/34)
