### PR TITLE
fix: #15 fix extra output log from connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## vNext
+- `solarwindsentityconnector` Fix extra output log issue by adding missing yaml tags for cache configuration parsing
 
 ## v0.127.5
 - `solarwindsentityconnector` Benchmark fix

--- a/connector/solarwindsentityconnector/config/expiration_policy.go
+++ b/connector/solarwindsentityconnector/config/expiration_policy.go
@@ -26,16 +26,16 @@ const (
 )
 
 type ExpirationPolicy struct {
-	Enabled bool `mapstructure:"enabled"`
+	Enabled bool `mapstructure:"enabled" yaml:"enabled"`
 	// TTL of relationships in the format accepted by time.ParseDuration, e.g. "5s", "1m", etc.
-	Interval           string              `mapstructure:"interval"`
-	CacheConfiguration *CacheConfiguration `mapstructure:"cache_configuration"`
+	Interval           string              `mapstructure:"interval" yaml:"interval"`
+	CacheConfiguration *CacheConfiguration `mapstructure:"cache_configuration" yaml:"cache_configuration"`
 }
 
 type CacheConfiguration struct {
-	MaxCapacity *int64 `mapstructure:"max_capacity"`
+	MaxCapacity *int64 `mapstructure:"max_capacity" yaml:"max_capacity"`
 	// In the format accepted by time.ParseDuration, e.g. "5s", "1m", etc. Granularity is 1 second and it's also a minimal value.
-	TTLCleanupInterval *string `mapstructure:"ttl_cleanup_interval"`
+	TTLCleanupInterval *string `mapstructure:"ttl_cleanup_interval" yaml:"ttl_cleanup_interval"`
 }
 
 type ExpirationSettings struct {

--- a/connector/solarwindsentityconnector/testdata/benchmark/config.yaml
+++ b/connector/solarwindsentityconnector/testdata/benchmark/config.yaml
@@ -1,8 +1,9 @@
 expiration_policy:
   enabled: true
-  interval: 1ms
+  interval: 10s
   cache_configuration:
-    ttl_cleanup_interval: 1ms
+    ttl_cleanup_interval: 20s
+    max_capacity: 2
 source_prefix: "src."
 destination_prefix: "dst."
 schema:
@@ -38,25 +39,25 @@ schema:
         source: "kubernetes.cluster"
         destination: "kubernetes.node"
         action: "update"
-        attributes:
+        attributes: []
       - context: "metric"
         conditions: ["true"]
         type: "test"
         source: "kubernetes.cluster"
         destination: "kubernetes.node"
         action: "update"
-        attributes:
+        attributes: []
       - context: "log"
         conditions: ["true"]
         type: "test"
         source: "kubernetes.node"
         destination: "kubernetes.node"
         action: "update"
-        attributes:
+        attributes: []
       - context: "metric"
         conditions: ["true"]
         type: "test"
         source: "kubernetes.node"
         destination: "kubernetes.node"
         action: "update"
-        attributes:
+        attributes: []


### PR DESCRIPTION
#### Description
Fix extra output log in solarwindsentityconnector by adding missing `yaml` tags for proper cache configuration parsing and change benchmark connector configuration.

#### Testing
Benchmark tests pass with correct log count.