### PR TITLE
fix: Support addresses ending with dot in `swok8sworkloadtypeprocessor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## vNext
 - `solarwindsentityconnector` Fix extra output log issue by adding missing yaml tags for cache configuration parsing
+- `swok8sworkloadtypeprocessor` Support addresses ending with dot
 
 ## v0.127.5
 - `solarwindsentityconnector` Benchmark fix

--- a/processor/swok8sworkloadtypeprocessor/internal/lookup.go
+++ b/processor/swok8sworkloadtypeprocessor/internal/lookup.go
@@ -231,6 +231,11 @@ func extractNameAndNamespaceAndType(host string) (name string, namespace string,
 			// "host" is a five words, so it could be a name, a namespace, a type and a cluster domain
 			return parts[4], parts[3], parts[2]
 		}
+	case 6:
+		if (parts[3] == serviceTypeShort || parts[3] == podTypeShort) && (parts[2] == "cluster" && parts[1] == "local" && parts[0] == "") {
+			// "host" is a six words, so it could be a name, a namespace, a type and a cluster domain ending with a dot
+			return parts[5], parts[4], parts[3]
+		}
 	}
 
 	// "host" is in an unknown format, so we don't know what it is

--- a/processor/swok8sworkloadtypeprocessor/processor_test.go
+++ b/processor/swok8sworkloadtypeprocessor/processor_test.go
@@ -421,6 +421,24 @@ func TestProcessorMetricsPipelineWhenSearchingByAddress(t *testing.T) {
 			},
 		},
 		{
+			name:         "mapping matches existing pods - <podname.namespace.pod.cluster.local.> only",
+			existingPods: []*corev1.Pod{testPod},
+			workloadMappings: []*K8sWorkloadMappingConfig{
+				{
+					AddressAttr:      "src_address",
+					WorkloadTypeAttr: "src_type",
+					ExpectedTypes:    []string{"pods"},
+				},
+			},
+			receivedMetricAttrs: map[string]any{
+				"src_address": testPod.Name + "." + testPod.Namespace + ".pod.cluster.local.",
+			},
+			expectedMetricAttrs: map[string]any{
+				"src_address": testPod.Name + "." + testPod.Namespace + ".pod.cluster.local.",
+				"src_type":    "Pod",
+			},
+		},
+		{
 			name:         "mapping matches existing pods - <podname.namespace.pod.cluster.local:8080> only",
 			existingPods: []*corev1.Pod{testPod},
 			workloadMappings: []*K8sWorkloadMappingConfig{


### PR DESCRIPTION
#### Description
When looking for k8s workloads based on a provided address, support addresses in format ending with a dot: `podname.namespace.pod.cluster.local.` and `podname.namespace.service.cluster.local.`.

#### Testing
Unit tests.
