### PR TITLE
chore: Ignore internal tools for CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,8 +50,8 @@ jobs:
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
     # or others). This is typically only required for manual builds.
-    # - name: Setup runtime (example)
-    #   uses: actions/setup-example@v1
+    - name: Remove Unsupported CodeQL Modules
+      run: rm -rf internal/tools
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
#### Description
Autobuilder has problem to build the internal/tools module (because of different approach to importing packages) so we want to ignore it, to have the configuration valid. The tools (add-license) is used just for prepending the header to files, nothing used for program execution.

The difference from previous [build](https://github.com/solarwinds/solarwinds-otel-collector-releases/actions/runs/16643728870/job/47099272655) (from releases, but it should be the same) is that there is no "Go files were found but not processed" mentioned in the logs for this PR build.

<!-- Issue number if applicable
**Tracking Issue:** https://github.com/solarwinds/solarwinds-otel-collector-contrib/issues/XXXX
-->

#### Testing
Describe what testing was performed and which tests were added.
