### PR TITLE
fix: #91 Fixing resolution of kubernetes Services in swok8sworkloadtypes

### DIFF
--- a/processor/swok8sworkloadtypeprocessor/internal/lookup.go
+++ b/processor/swok8sworkloadtypeprocessor/internal/lookup.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
@@ -54,6 +55,31 @@ func extractWorkloadKind(workload any, logger *zap.Logger, informers map[string]
 		return EmptyLookupResult
 	}
 	kind := workloadObject.GetObjectKind().GroupVersionKind().Kind
+
+	// Fallback to type-based detection if GVK is not populated (common with fake clients)
+	if kind == "" {
+		switch workload.(type) {
+		case *corev1.Service:
+			kind = ServiceKind
+		case *corev1.Pod:
+			kind = PodKind
+		default:
+			logger.Debug("Unknown workload type, checking with runtime reflection", zap.String("workloadObjectType", fmt.Sprintf("%T", workload)))
+			// Try to extract from the type name as last resort
+			typeName := fmt.Sprintf("%T", workload)
+			if strings.Contains(typeName, ".Service") {
+				kind = ServiceKind
+			} else if strings.Contains(typeName, ".Pod") {
+				kind = PodKind
+			} else if strings.Contains(typeName, ".Deployment") {
+				kind = "Deployment"
+			} else if strings.Contains(typeName, ".StatefulSet") {
+				kind = "StatefulSet"
+			} else if strings.Contains(typeName, ".ReplicaSet") {
+				kind = ReplicaSetKind
+			}
+		}
+	}
 
 	if preferPodOwner && kind == PodKind {
 		ownerKind := lookupOwnerKindForWorkload(workload, logger, informers)
@@ -132,17 +158,49 @@ func lookupWorkloadByNameAndNamespace(name string, namespace string, expectedTyp
 		workloadKey = fmt.Sprintf("%s/%s", namespace, name)
 	}
 
+	logger.Debug("lookupWorkloadByNameAndNamespace called",
+		zap.String("name", name),
+		zap.String("namespace", namespace),
+		zap.String("workloadKey", workloadKey),
+		zap.Strings("expectedTypes", expectedTypes))
+
 	for _, workloadType := range expectedTypes {
 		logger := logger.WithLazy(zap.String("workloadType", workloadType), zap.String("workloadKey", workloadKey))
-		workload, exists, err := informers[workloadType].GetStore().GetByKey(workloadKey)
+
+		// Check if informer exists for this workload type
+		informer, exists := informers[workloadType]
+		if !exists {
+			logger.Debug("No informer found for workload type", zap.String("workloadType", workloadType))
+			continue
+		}
+
+		logger.Debug("Checking workload in cache",
+			zap.String("workloadType", workloadType),
+			zap.String("workloadKey", workloadKey))
+
+		workload, exists, err := informer.GetStore().GetByKey(workloadKey)
 		if err != nil {
 			logger.Error("Error getting workload from cache", zap.Error(err))
 			continue
 		}
 		if exists {
+			// Log the type of workload found for debugging
+			logger.Debug("Found workload in cache",
+				zap.String("workloadType", workloadType),
+				zap.String("workloadKey", workloadKey),
+				zap.String("workloadObjectType", fmt.Sprintf("%T", workload)))
 			return workload
+		} else {
+			logger.Debug("Workload not found in cache",
+				zap.String("workloadType", workloadType),
+				zap.String("workloadKey", workloadKey))
 		}
 	}
+
+	logger.Debug("No workload found in any cache",
+		zap.String("name", name),
+		zap.String("namespace", namespace),
+		zap.Strings("expectedTypes", expectedTypes))
 	return nil
 }
 
@@ -150,11 +208,27 @@ func lookupWorkloadByNameAndNamespace(name string, namespace string, expectedTyp
 // The list of ExpectedTypes in K8sWorkloadMappingConfig is used to determine which workload types to check.
 // It returns the kind of the workload if found, or an empty result if not found.
 func LookupWorkloadKindByNameAndNamespace(name string, namespace string, expectedTypes []string, logger *zap.Logger, informers map[string]cache.SharedIndexInformer, preferPodOwner bool) LookupResult {
+	logger.Debug("LookupWorkloadKindByNameAndNamespace called",
+		zap.String("name", name),
+		zap.String("namespace", namespace),
+		zap.Strings("expectedTypes", expectedTypes),
+		zap.Bool("preferPodOwner", preferPodOwner))
+
 	workload := lookupWorkloadByNameAndNamespace(name, namespace, expectedTypes, logger, informers)
 	if workload == nil {
+		logger.Debug("No workload found by name and namespace",
+			zap.String("name", name),
+			zap.String("namespace", namespace))
 		return EmptyLookupResult
 	} else {
-		return extractWorkloadKind(workload, logger, informers, preferPodOwner)
+		result := extractWorkloadKind(workload, logger, informers, preferPodOwner)
+		logger.Debug("Found workload by name and namespace",
+			zap.String("name", name),
+			zap.String("namespace", namespace),
+			zap.String("resultKind", result.Kind),
+			zap.String("resultName", result.Name),
+			zap.String("resultNamespace", result.Namespace))
+		return result
 	}
 }
 
@@ -206,14 +280,18 @@ func LookupWorkloadKindByIp(ip string, expectedTypes []string, logger *zap.Logge
 	return EmptyLookupResult
 }
 
-// extractNameAndNamespaceAndType extracts the possible name, namespace and type from the host string.
+// ExtractNameAndNamespaceAndType extracts the possible name, namespace and type from the host string.
 // It returns empty strings if the host is in an unknown format.
 //
 // The returned workloadTypeShort is either "pod", "svc" or empty. If not empty, the returned name and namespace are definite.
 // Otherwise, the returned name and namespace are only possible values.
-func extractNameAndNamespaceAndType(host string) (name string, namespace string, workloadTypeShort string) {
+func ExtractNameAndNamespaceAndType(host string) (name string, namespace string, workloadTypeShort string) {
 	parts := strings.Split(host, ".")
 	slices.Reverse(parts)
+
+	// Log for debugging hostname parsing
+	// Note: This function doesn't have logger parameter, so we'll log from calling function
+
 	switch len(parts) {
 	case 1:
 		// "host" is a single word, so it could be a name
@@ -244,59 +322,70 @@ func extractNameAndNamespaceAndType(host string) (name string, namespace string,
 
 // LookupWorkloadKindByHostname looks up the workload kind by hostname.
 // It extracts the name and namespace from the hostname and uses them to look up the workload type.
-// The namespaceFromAttr is used to validate the namespace extracted from the hostname.
+// If namespace is not found in hostname, it can be provided via the namespace parameter.
 // The expectedTypes are used to determine which workload types to check.
-// It returns the kind of the workload if found, or an empty result if not found or if there is a mismatch in namespaces.
+// It returns the kind of the workload if found, or an empty result if not found.
 // If the hostname is in an unknown format, it returns an empty result.
 // It has a special handling for well-known DNS formats for Pods and Services.
-func LookupWorkloadKindByHostname(hostname string, namespaceFromAttr string, expectedTypes []string, logger *zap.Logger, informers map[string]cache.SharedIndexInformer, preferPodOwner bool) LookupResult {
-	nameFromHostname, namespaceFromHostname, workloadTypeShort := extractNameAndNamespaceAndType(hostname)
+func LookupWorkloadKindByHostname(hostname string, namespace string, expectedTypes []string, logger *zap.Logger, informers map[string]cache.SharedIndexInformer, preferPodOwner bool) LookupResult {
+	logger.Debug("LookupWorkloadKindByHostname called",
+		zap.String("hostname", hostname),
+		zap.String("namespace", namespace),
+		zap.Strings("expectedTypes", expectedTypes),
+		zap.Bool("preferPodOwner", preferPodOwner))
+
+	nameFromHostname, namespaceFromHostname, workloadTypeShort := ExtractNameAndNamespaceAndType(hostname)
+	logger.Debug("Extracted hostname components",
+		zap.String("hostname", hostname),
+		zap.String("nameFromHostname", nameFromHostname),
+		zap.String("namespaceFromHostname", namespaceFromHostname),
+		zap.String("workloadTypeShort", workloadTypeShort),
+		zap.Strings("hostnameParts", strings.Split(hostname, ".")))
+
 	if nameFromHostname == "" {
 		// It's unclear what the address is, so we can't determine the workload kind
+		logger.Debug("Could not extract name from hostname, returning empty result", zap.String("hostname", hostname))
 		return EmptyLookupResult
+	}
+
+	// Use namespace from hostname if available, otherwise use provided namespace
+	effectiveNamespace := namespaceFromHostname
+	if effectiveNamespace == "" {
+		effectiveNamespace = namespace
 	}
 
 	switch workloadTypeShort {
 	case podTypeShort:
-		if namespaceFromAttr != "" && namespaceFromHostname != namespaceFromAttr {
-			// The namespace in the address does not match the one in the attributes. This is suspicious.
-			logger.Warn("Namespace mismatch", zap.String("namespaceInAddress", namespaceFromHostname), zap.String("namespaceInAttributes", namespaceFromAttr))
-			return EmptyLookupResult
-		}
+		logger.Debug("Hostname indicates pod type", zap.String("hostname", hostname))
 
 		if preferPodOwner {
-			ownerKind := lookupOwnerKindByNameAndNamespace(nameFromHostname, namespaceFromHostname, PodsWorkloadType, logger, informers)
+			logger.Debug("Attempting to find pod owner", zap.String("podName", nameFromHostname), zap.String("namespace", effectiveNamespace))
+			ownerKind := lookupOwnerKindByNameAndNamespace(nameFromHostname, effectiveNamespace, PodsWorkloadType, logger, informers)
 			if ownerKind != EmptyLookupResult {
+				logger.Debug("Found pod owner", zap.String("ownerKind", ownerKind.Kind), zap.String("ownerName", ownerKind.Name))
 				return ownerKind
 			}
+			logger.Debug("No pod owner found, returning pod itself")
 		}
 
 		return LookupResult{
 			Name:      nameFromHostname,
-			Namespace: namespaceFromHostname,
+			Namespace: effectiveNamespace,
 			Kind:      PodKind,
 		}
 	case serviceTypeShort:
-		if namespaceFromAttr != "" && namespaceFromHostname != namespaceFromAttr {
-			// The namespace in the address does not match the one in the attributes. This is suspicious.
-			logger.Warn("Namespace mismatch", zap.String("namespaceInAddress", namespaceFromHostname), zap.String("namespaceInAttributes", namespaceFromAttr))
-			return EmptyLookupResult
-		}
+		logger.Debug("Hostname indicates service type", zap.String("hostname", hostname))
 		return LookupResult{
 			Name:      nameFromHostname,
-			Namespace: namespaceFromHostname,
+			Namespace: effectiveNamespace,
 			Kind:      ServiceKind,
 		}
 	default:
-		if namespaceFromAttr != "" && namespaceFromHostname != "" && namespaceFromHostname != namespaceFromAttr {
-			// The namespace in the address does not match the one in the attributes. It's unclear what the address is, so we can't determine the workload kind.
-			return EmptyLookupResult
-		}
-		ns := namespaceFromHostname
-		if ns == "" {
-			ns = namespaceFromAttr
-		}
+		logger.Debug("Hostname type unknown, using fallback lookup", zap.String("hostname", hostname))
 
-		return LookupWorkloadKindByNameAndNamespace(nameFromHostname, ns, expectedTypes, logger, informers, preferPodOwner)
+		logger.Debug("Using fallback lookup by name and namespace",
+			zap.String("name", nameFromHostname),
+			zap.String("namespace", effectiveNamespace))
+		return LookupWorkloadKindByNameAndNamespace(nameFromHostname, effectiveNamespace, expectedTypes, logger, informers, preferPodOwner)
 	}
 }

--- a/processor/swok8sworkloadtypeprocessor/internal/lookup_test.go
+++ b/processor/swok8sworkloadtypeprocessor/internal/lookup_test.go
@@ -1,0 +1,157 @@
+// Copyright 2025 SolarWinds Worldwide, LLC. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// TestLookupWorkloadKindByNameAndNamespace tests the basic lookup functionality
+func TestLookupWorkloadKindByNameAndNamespace(t *testing.T) {
+	logger := zap.NewNop()
+
+	// Create a test service
+	testService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-service",
+			Namespace: "test-namespace",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+	}
+
+	serviceInformer := cache.NewSharedIndexInformer(
+		nil, // ListerWatcher is nil for testing
+		testService,
+		0, // resyncPeriod
+		cache.Indexers{},
+	)
+	err := serviceInformer.GetStore().Add(testService)
+	assert.NoError(t, err)
+
+	informers := map[string]cache.SharedIndexInformer{
+		ServicesWorkloadType: serviceInformer,
+	}
+
+	// Test successful lookup with both name and namespace
+	result := LookupWorkloadKindByNameAndNamespace(
+		"test-service",
+		"test-namespace",
+		[]string{ServicesWorkloadType},
+		logger,
+		informers,
+		false,
+	)
+
+	assert.Equal(t, "test-service", result.Name)
+	assert.Equal(t, "test-namespace", result.Namespace)
+	assert.Equal(t, ServiceKind, result.Kind)
+}
+
+// TestLookupWorkloadKindByNameAndNamespaceNotFound tests that lookup returns nil when not found
+func TestLookupWorkloadKindByNameAndNamespaceNotFound(t *testing.T) {
+	logger := zap.NewNop()
+
+	serviceInformer := cache.NewSharedIndexInformer(
+		nil, // ListerWatcher is nil for testing
+		&corev1.Service{},
+		0, // resyncPeriod
+		cache.Indexers{},
+	)
+
+	informers := map[string]cache.SharedIndexInformer{
+		ServicesWorkloadType: serviceInformer,
+	}
+
+	// Test lookup with non-existent service
+	result := LookupWorkloadKindByNameAndNamespace(
+		"non-existent-service",
+		"test-namespace",
+		[]string{ServicesWorkloadType},
+		logger,
+		informers,
+		false,
+	)
+
+	assert.Equal(t, "", result.Name, "Should not find non-existent service")
+	assert.Equal(t, "", result.Namespace, "Should not find non-existent service")
+	assert.Equal(t, "", result.Kind, "Should not find non-existent service")
+}
+
+// TestLookupWorkloadByNameAndNamespace tests the internal lookup function
+func TestLookupWorkloadByNameAndNamespace(t *testing.T) {
+	logger := zap.NewNop()
+
+	// Create a test service
+	testService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-service",
+			Namespace: "test-namespace",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+	}
+
+	serviceInformer := cache.NewSharedIndexInformer(
+		nil, // ListerWatcher is nil for testing
+		testService,
+		0, // resyncPeriod
+		cache.Indexers{},
+	)
+	err := serviceInformer.GetStore().Add(testService)
+	assert.NoError(t, err)
+
+	informers := map[string]cache.SharedIndexInformer{
+		ServicesWorkloadType: serviceInformer,
+	}
+
+	// Test successful lookup
+	result := lookupWorkloadByNameAndNamespace(
+		"test-service",
+		"test-namespace",
+		[]string{ServicesWorkloadType},
+		logger,
+		informers,
+	)
+
+	assert.NotNil(t, result, "Should find the service")
+
+	// Cast result to proper type to check fields
+	service, ok := result.(*corev1.Service)
+	assert.True(t, ok, "Result should be a Service")
+	assert.Equal(t, "test-service", service.Name)
+	assert.Equal(t, "test-namespace", service.Namespace)
+
+	// Test lookup with empty namespace (should fail without cross-namespace fallback)
+	result2 := lookupWorkloadByNameAndNamespace(
+		"test-service",
+		"",
+		[]string{ServicesWorkloadType},
+		logger,
+		informers,
+	)
+
+	assert.Nil(t, result2, "Should not find service with empty namespace")
+}

--- a/processor/swok8sworkloadtypeprocessor/processor.go
+++ b/processor/swok8sworkloadtypeprocessor/processor.go
@@ -51,65 +51,170 @@ func (cp *swok8sworkloadtypeProcessor) getAttribute(attributes pcommon.Map, attr
 type dataPointSlice[DP dataPoint] interface{ All() iter.Seq2[int, DP] }
 type dataPoint interface{ Attributes() pcommon.Map }
 
-func processDatapoints[DPS dataPointSlice[DP], DP dataPoint](cp *swok8sworkloadtypeProcessor, datapoints DPS) {
+func processDatapoints[DPS dataPointSlice[DP], DP dataPoint](cp *swok8sworkloadtypeProcessor, datapoints DPS, resourceAttributes pcommon.Map) {
+	cp.logger.Debug("processDatapoints called")
 	for _, dp := range datapoints.All() {
-		processAttributes(cp, dp.Attributes(), DataPointContext)
+		cp.logger.Debug("Processing datapoint")
+		processAttributesWithResourceFallback(cp, dp.Attributes(), DataPointContext, resourceAttributes)
 	}
 }
 
 func processAttributes(cp *swok8sworkloadtypeProcessor, attributes pcommon.Map, statementContext statementContext) {
-	for _, workloadMapping := range cp.config.WorkloadMappings {
+	processAttributesWithResourceFallback(cp, attributes, statementContext, pcommon.NewMap())
+}
+
+func processAttributesWithResourceFallback(cp *swok8sworkloadtypeProcessor, attributes pcommon.Map, statementContext statementContext, resourceAttributes pcommon.Map) {
+	cp.logger.Debug("processAttributes called",
+		zap.String("context", string(statementContext)),
+		zap.Int("workloadMappingsCount", len(cp.config.WorkloadMappings)))
+
+	for i, workloadMapping := range cp.config.WorkloadMappings {
+		cp.logger.Debug("Checking workload mapping",
+			zap.Int("index", i),
+			zap.String("context", string(statementContext)),
+			zap.String("mappingContext", string(workloadMapping.context)))
+
 		if workloadMapping.context != statementContext {
+			cp.logger.Debug("Skipping workload mapping due to context mismatch",
+				zap.String("expectedContext", string(statementContext)),
+				zap.String("mappingContext", string(workloadMapping.context)))
 			continue
 		}
+
+		cp.logger.Debug("Processing workload mapping",
+			zap.String("context", string(statementContext)),
+			zap.String("nameAttr", workloadMapping.NameAttr),
+			zap.String("addressAttr", workloadMapping.AddressAttr),
+			zap.String("namespaceAttr", workloadMapping.NamespaceAttr),
+			zap.String("workloadTypeAttr", workloadMapping.WorkloadTypeAttr),
+			zap.Strings("expectedTypes", workloadMapping.ExpectedTypes),
+			zap.Bool("preferOwnerForPods", workloadMapping.PreferOwnerForPods))
 
 		if cp.getAttribute(attributes, workloadMapping.WorkloadTypeAttr) != "" {
 			// Skip if the workload type attribute is already set
+			cp.logger.Debug("Skipping workload mapping - workload type already set",
+				zap.String("workloadTypeAttr", workloadMapping.WorkloadTypeAttr),
+				zap.String("existingValue", cp.getAttribute(attributes, workloadMapping.WorkloadTypeAttr)))
 			continue
 		}
 
+		// Log input attributes for debugging
+		allAttrs := make(map[string]interface{})
+		attributes.Range(func(k string, v pcommon.Value) bool {
+			allAttrs[k] = v.AsString()
+			return true
+		})
+		cp.logger.Debug("Input attributes for workload mapping", zap.Any("attributes", allAttrs))
+
 		var res internal.LookupResult
 		if workloadMapping.NameAttr != "" {
-			res = cp.lookupWorkloadTypeByNameAttr(workloadMapping, attributes)
+			res = cp.lookupWorkloadTypeByNameAttrWithResourceFallback(workloadMapping, attributes, resourceAttributes)
 		} else if workloadMapping.AddressAttr != "" {
-			res = cp.lookupWorkloadTypeByAddressAttr(workloadMapping, attributes)
+			res = cp.lookupWorkloadTypeByAddressAttrWithResourceFallback(workloadMapping, attributes, resourceAttributes)
 		} else {
 			cp.logger.Error("Unexpected workload mapping configuration")
 			continue
 		}
+
+		cp.logger.Debug("Lookup result",
+			zap.String("resultKind", res.Kind),
+			zap.String("resultName", res.Name),
+			zap.String("resultNamespace", res.Namespace))
+
 		if res.Kind != "" {
 			attributes.PutStr(workloadMapping.WorkloadTypeAttr, res.Kind)
+			cp.logger.Debug("Set workload type attribute",
+				zap.String("attribute", workloadMapping.WorkloadTypeAttr),
+				zap.String("value", res.Kind))
 		}
 		if res.Name != "" && workloadMapping.WorkloadNameAttr != "" {
 			attributes.PutStr(workloadMapping.WorkloadNameAttr, res.Name)
+			cp.logger.Debug("Set workload name attribute",
+				zap.String("attribute", workloadMapping.WorkloadNameAttr),
+				zap.String("value", res.Name))
 		}
 		if res.Namespace != "" && workloadMapping.WorkloadNamespaceAttr != "" {
 			attributes.PutStr(workloadMapping.WorkloadNamespaceAttr, res.Namespace)
+			cp.logger.Debug("Set workload namespace attribute",
+				zap.String("attribute", workloadMapping.WorkloadNamespaceAttr),
+				zap.String("value", res.Namespace))
 		}
 	}
 }
 
 func (cp *swok8sworkloadtypeProcessor) lookupWorkloadTypeByNameAttr(workloadMapping *K8sWorkloadMappingConfig, attributes pcommon.Map) internal.LookupResult {
+	return cp.lookupWorkloadTypeByNameAttrWithResourceFallback(workloadMapping, attributes, pcommon.NewMap())
+}
+
+func (cp *swok8sworkloadtypeProcessor) lookupWorkloadTypeByNameAttrWithResourceFallback(workloadMapping *K8sWorkloadMappingConfig, attributes pcommon.Map, resourceAttributes pcommon.Map) internal.LookupResult {
 	name := cp.getAttribute(attributes, workloadMapping.NameAttr)
 	if name == "" {
+		cp.logger.Debug("Name attribute not found or empty",
+			zap.String("nameAttr", workloadMapping.NameAttr))
 		return internal.EmptyLookupResult
 	}
+
+	// Try to get namespace from attributes first, then fallback to resource attributes
 	namespace := cp.getAttribute(attributes, workloadMapping.NamespaceAttr)
+	if namespace == "" && workloadMapping.NamespaceAttr != "" {
+		namespace = cp.getAttribute(resourceAttributes, workloadMapping.NamespaceAttr)
+		if namespace != "" {
+			cp.logger.Debug("Using namespace from resource attributes as fallback",
+				zap.String("namespaceAttr", workloadMapping.NamespaceAttr),
+				zap.String("namespace", namespace))
+		}
+	}
+
+	cp.logger.Debug("Looking up workload by name and namespace",
+		zap.String("name", name),
+		zap.String("namespace", namespace),
+		zap.String("nameAttr", workloadMapping.NameAttr),
+		zap.String("namespaceAttr", workloadMapping.NamespaceAttr),
+		zap.Strings("expectedTypes", workloadMapping.ExpectedTypes),
+		zap.Bool("preferOwnerForPods", workloadMapping.PreferOwnerForPods))
 
 	return internal.LookupWorkloadKindByNameAndNamespace(name, namespace, workloadMapping.ExpectedTypes, cp.logger, cp.informers, workloadMapping.PreferOwnerForPods)
 }
 
 func (cp *swok8sworkloadtypeProcessor) lookupWorkloadTypeByAddressAttr(workloadMapping *K8sWorkloadMappingConfig, attributes pcommon.Map) internal.LookupResult {
+	return cp.lookupWorkloadTypeByAddressAttrWithResourceFallback(workloadMapping, attributes, pcommon.NewMap())
+}
+
+func (cp *swok8sworkloadtypeProcessor) lookupWorkloadTypeByAddressAttrWithResourceFallback(workloadMapping *K8sWorkloadMappingConfig, attributes pcommon.Map, resourceAttributes pcommon.Map) internal.LookupResult {
 	addr := cp.getAttribute(attributes, workloadMapping.AddressAttr)
 	if addr == "" {
+		cp.logger.Debug("Address attribute not found or empty",
+			zap.String("addressAttr", workloadMapping.AddressAttr))
 		return internal.EmptyLookupResult
 	}
 	host := internal.ExtractHostFromAddress(addr)
 
+	cp.logger.Debug("Looking up workload by address",
+		zap.String("address", addr),
+		zap.String("extractedHost", host),
+		zap.String("addressAttr", workloadMapping.AddressAttr),
+		zap.Strings("expectedTypes", workloadMapping.ExpectedTypes),
+		zap.Bool("preferOwnerForPods", workloadMapping.PreferOwnerForPods))
+
 	if net.ParseIP(host) != nil {
+		cp.logger.Debug("Host is an IP address, looking up by IP", zap.String("ip", host))
 		return internal.LookupWorkloadKindByIp(host, workloadMapping.ExpectedTypes, cp.logger, cp.informers, workloadMapping.PreferOwnerForPods)
 	} else {
+		// Try to get namespace from attributes first, then fallback to resource attributes
 		namespace := cp.getAttribute(attributes, workloadMapping.NamespaceAttr)
+		if namespace == "" && workloadMapping.NamespaceAttr != "" {
+			namespace = cp.getAttribute(resourceAttributes, workloadMapping.NamespaceAttr)
+			if namespace != "" {
+				cp.logger.Debug("Using namespace from resource attributes as fallback for address lookup",
+					zap.String("namespaceAttr", workloadMapping.NamespaceAttr),
+					zap.String("namespace", namespace))
+			}
+		}
+
+		cp.logger.Debug("Host is a hostname, looking up by hostname",
+			zap.String("hostname", host),
+			zap.String("namespace", namespace),
+			zap.String("namespaceAttr", workloadMapping.NamespaceAttr))
 		return internal.LookupWorkloadKindByHostname(host, namespace, workloadMapping.ExpectedTypes, cp.logger, cp.informers, workloadMapping.PreferOwnerForPods)
 	}
 }
@@ -124,15 +229,15 @@ func (cp *swok8sworkloadtypeProcessor) processMetrics(ctx context.Context, md pm
 
 				switch m.Type() {
 				case pmetric.MetricTypeGauge:
-					processDatapoints(cp, m.Gauge().DataPoints())
+					processDatapoints(cp, m.Gauge().DataPoints(), rm.Resource().Attributes())
 				case pmetric.MetricTypeSum:
-					processDatapoints(cp, m.Sum().DataPoints())
+					processDatapoints(cp, m.Sum().DataPoints(), rm.Resource().Attributes())
 				case pmetric.MetricTypeHistogram:
-					processDatapoints(cp, m.Histogram().DataPoints())
+					processDatapoints(cp, m.Histogram().DataPoints(), rm.Resource().Attributes())
 				case pmetric.MetricTypeExponentialHistogram:
-					processDatapoints(cp, m.ExponentialHistogram().DataPoints())
+					processDatapoints(cp, m.ExponentialHistogram().DataPoints(), rm.Resource().Attributes())
 				case pmetric.MetricTypeSummary:
-					processDatapoints(cp, m.Summary().DataPoints())
+					processDatapoints(cp, m.Summary().DataPoints(), rm.Resource().Attributes())
 				default:
 					cp.logger.Debug("Unsupported metric type", zap.Any("metricType", m.Type()))
 					continue


### PR DESCRIPTION
#### Description
Made lookup to cache more robust, also adding debug logs for easier investigation in the future.

**Tracking Issue:** https://github.com/solarwinds/solarwinds-otel-collector-contrib/issues/91

#### Details
In case of datapoint with following attributes:

server.address="test-communicator-http-2-service:8081"
and this resource attribute:
k8s.namespace.name="test-namespace"
and this configuration:

swok8sworkloadtype/beyla:
    workload_mappings:
      - address_attr: server.address
        namespace_attr: k8s.namespace.name
        workload_type_attr: sw.k8s.dst.workload.type
        workload_name_attr: sw.k8s.dst.workload.name
        workload_namespace_attr: sw.k8s.dst.workload.namespace
        prefer_owner_for_pods: true
        expected_types:
          - services
          - pods
it does not correctly resolve Service even if it is already in cache. This is mainly because it process datapoint attributes and resource attributes separately.

##### Fix
It now fallbacks to resource attribute when doing attribute lookup.

#### Testing
Unit tests and local cluster
