### PR TITLE
chore: Add handling for empty metrics in scope emitter and tests

### DIFF
--- a/receiver/swohostmetricsreceiver/internal/scraper/framework/scope/emitter.go
+++ b/receiver/swohostmetricsreceiver/internal/scraper/framework/scope/emitter.go
@@ -181,7 +181,17 @@ func (s *emitter) assemblyScopeMetricSlice(
 
 	// Setup metrics into scope metric slice.
 	for _, m := range ms {
-		m.MoveAndAppendTo(sm.Metrics())
+		if m.Len() != 0 {
+			m.MoveAndAppendTo(sm.Metrics())
+		}
+	}
+
+	if sm.Metrics().Len() == 0 {
+		s.logger.Debug(
+			"no metrics available for scope after filtering metric slices, returning empty scope metrics slice",
+			zap.String("scope_name", s.scopeName),
+		)
+		return pmetric.NewScopeMetricsSlice(), nil
 	}
 
 	s.logger.Debug(

--- a/receiver/swohostmetricsreceiver/internal/scraper/framework/scope/emitter_test.go
+++ b/receiver/swohostmetricsreceiver/internal/scraper/framework/scope/emitter_test.go
@@ -42,3 +42,49 @@ func Test_Example_HowToFillScopeMetrics(t *testing.T) {
 	assert.Equal(t, 2, rm.ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().Len(), "Number of data points must fit")
 	assert.Equal(t, int64(1701), rm.ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0).IntValue(), "Value must be the same")
 }
+
+func Test_ScopeEmitter_EmptyMetrics_ReturnsEmptyScope(t *testing.T) {
+	// Create an empty scope metrics slice
+	emptyScopeData := pmetric.NewScopeMetricsSlice()
+
+	// Create scope emitter mock that returns empty data
+	scopeEmitter := CreateEmitterMock(
+		&Result{
+			Data:  emptyScopeData,
+			Error: nil,
+		},
+		nil,
+		"test.scope",
+	)
+
+	// Initialize and emit
+	err := scopeEmitter.Init()
+	assert.NoError(t, err, "scope emitter initialization should succeed")
+
+	result := scopeEmitter.Emit()
+	assert.NoError(t, result.Error, "scope emitter should not return error for empty metrics")
+	assert.Equal(t, 0, result.Data.Len(), "scope metrics slice should be empty")
+}
+
+func Test_ScopeEmitter_AllEmptyMetrics_ReturnsEmptyScope(t *testing.T) {
+	// Create an empty scope metrics slice
+	emptyScopeData := pmetric.NewScopeMetricsSlice()
+
+	// Create scope emitter mock that returns empty data
+	scopeEmitter := CreateEmitterMock(
+		&Result{
+			Data:  emptyScopeData,
+			Error: nil,
+		},
+		nil,
+		"test.scope.all.empty",
+	)
+
+	// Initialize and emit
+	err := scopeEmitter.Init()
+	assert.NoError(t, err, "scope emitter initialization should succeed")
+
+	result := scopeEmitter.Emit()
+	assert.NoError(t, result.Error, "scope emitter should not return error when all metrics are empty")
+	assert.Equal(t, 0, result.Data.Len(), "scope metrics slice should be empty when all metrics are empty")
+}

--- a/receiver/swohostmetricsreceiver/internal/scraper/hardwareinventoryscraper/metrics/cpu/emitter.go
+++ b/receiver/swohostmetricsreceiver/internal/scraper/hardwareinventoryscraper/metrics/cpu/emitter.go
@@ -73,6 +73,12 @@ func (*emitter) Name() string {
 }
 
 func (e *emitter) constructMetricSlice(processors []cpuProvider.Processor) (pmetric.MetricSlice, error) {
+
+	// If there are no processors, return an empty metric slice
+	if len(processors) == 0 {
+		return pmetric.NewMetricSlice(), nil
+	}
+
 	ms := pmetric.NewMetricSlice()
 	ms.EnsureCapacity(1)
 


### PR DESCRIPTION
#### Description
This pull request improves the handling of empty metrics in the scope emitter logic and adds.
* Updated `assemblyScopeMetricSlice` in `emitter.go` to filter out empty metric slices and return an empty scope metrics slice if no metrics remain after filtering.
* Modified `constructMetricSlice` in `cpu/emitter.go` to immediately return an empty metric slice if the processor list is empty, avoiding unnecessary metric creation.

#### Testing
Added two new test cases in `emitter_test.go` to verify that the scope emitter correctly returns an empty scope metrics slice when provided with empty metrics or when all metrics are empty.