### PR TITLE
chore: prepare release 0.131.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+## v0.131.6
+
 ## v0.131.5
 - `swohostmetricsreceiver` Add handling for empty metrics in scope emitter
 - `solarwindsprocessor` Add decoration of host resource attributes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## vNext
 
 ## v0.131.6
+- `pkg/container` Fix module name in go.mod
 
 ## v0.131.5
 - `swohostmetricsreceiver` Add handling for empty metrics in scope emitter

--- a/extension/solarwindsextension/go.mod
+++ b/extension/solarwindsextension/go.mod
@@ -3,8 +3,8 @@ module github.com/solarwinds/solarwinds-otel-collector-contrib/extension/solarwi
 go 1.25.0
 
 require (
-	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/testutil v0.131.5
-	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/version v0.131.5
+	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/testutil v0.131.6
+	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/version v0.131.6
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.37.0
 	go.opentelemetry.io/collector/component/componenttest v0.131.0

--- a/pkg/container/go.mod
+++ b/pkg/container/go.mod
@@ -1,4 +1,4 @@
-module container
+module github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/container
 
 go 1.25.0
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,4 +14,4 @@
 
 package version
 
-const Version = "0.131.5"
+const Version = "0.131.6"

--- a/processor/solarwindsprocessor/go.mod
+++ b/processor/solarwindsprocessor/go.mod
@@ -4,10 +4,10 @@ go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0
-	github.com/solarwinds/solarwinds-otel-collector-contrib/extension/solarwindsextension v0.131.5
-	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/attributesdecorator v0.131.5
-	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/container v0.131.5
-	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/extensionfinder v0.131.5
+	github.com/solarwinds/solarwinds-otel-collector-contrib/extension/solarwindsextension v0.131.6
+	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/attributesdecorator v0.131.6
+	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/container v0.131.6
+	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/extensionfinder v0.131.6
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.37.0
 	go.opentelemetry.io/collector/component/componenttest v0.131.0
@@ -47,7 +47,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/mostynb/go-grpc-compression v1.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/version v0.131.5 // indirect
+	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/version v0.131.6 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector v0.131.0 // indirect
 	go.opentelemetry.io/collector/client v1.37.0 // indirect

--- a/processor/swok8sworkloadstatusprocessor/go.mod
+++ b/processor/swok8sworkloadstatusprocessor/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/solarwinds/solarwinds-otel-collector-contrib/internal/k8sconfig v0.131.5
+	github.com/solarwinds/solarwinds-otel-collector-contrib/internal/k8sconfig v0.131.6
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/component/componentstatus v0.131.0 // indirect
 	go.opentelemetry.io/collector/component/componenttest v0.131.0

--- a/processor/swok8sworkloadtypeprocessor/go.mod
+++ b/processor/swok8sworkloadtypeprocessor/go.mod
@@ -3,7 +3,7 @@ module github.com/solarwinds/solarwinds-otel-collector-contrib/processor/swok8sw
 go 1.25.0
 
 require (
-	github.com/solarwinds/solarwinds-otel-collector-contrib/internal/k8sconfig v0.131.5
+	github.com/solarwinds/solarwinds-otel-collector-contrib/internal/k8sconfig v0.131.6
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.37.0
 	go.opentelemetry.io/collector/component/componenttest v0.131.0

--- a/receiver/swohostmetricsreceiver/go.mod
+++ b/receiver/swohostmetricsreceiver/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/go-ole/go-ole v1.3.0
 	github.com/google/go-cmp v0.7.0
 	github.com/shirou/gopsutil/v4 v4.25.7
-	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/registry v0.131.5
-	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/testutil v0.131.5
-	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/version v0.131.5
-	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/wmi v0.131.5
+	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/registry v0.131.6
+	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/testutil v0.131.6
+	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/version v0.131.6
+	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/wmi v0.131.6
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.37.0
 	go.opentelemetry.io/collector/component/componenttest v0.131.0

--- a/receiver/swok8sobjectsreceiver/go.mod
+++ b/receiver/swok8sobjectsreceiver/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.131.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.131.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/xk8stest v0.131.0
-	github.com/solarwinds/solarwinds-otel-collector-contrib/internal/k8sconfig v0.131.5
+	github.com/solarwinds/solarwinds-otel-collector-contrib/internal/k8sconfig v0.131.6
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.37.0
 	go.opentelemetry.io/collector/component/componenttest v0.131.0


### PR DESCRIPTION
#### Description
`0.131.6` is fix for container package. The go.mod now contains correct way of referencing to go module.
<!-- Issue number if applicable
**Tracking Issue:** https://github.com/solarwinds/solarwinds-otel-collector-contrib/issues/XXXX
-->

#### Testing
Describe what testing was performed and which tests were added.
