### PR TITLE
chore: update dependabot config to ignore k8s.io group

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -28,10 +28,13 @@ updates:
       time: "03:30"
     allow:
       - dependency-type: "direct"
-    # these are to be handled by opentelemtery bumps, and releases
     ignore:
+      # these are to be handled by opentelemtery bumps, and releases
       - dependency-name: "*opentelemetry*"
       - dependency-name: "*solarwinds-otel-collector*"
+      # k8s.io bumps must be tightly bound to bumps of opentelemetry dependencies, 
+      # bumping them independently results in build failures due to incompatibility
+      - dependency-name: "*k8s.io*"
     groups:
       components-security:
         applies-to: security-updates
@@ -40,11 +43,9 @@ updates:
         exclude-patterns:
           - "*opentelemetry*"
           - "*solarwinds-otel-collector*"
+          - "*k8s.io*"
         update-types:
           - "patch"
           - "minor"
-      k8s-io:
-        patterns:
-          - "*k8s.io*"
     commit-message:
       prefix: "chore: "


### PR DESCRIPTION
#### Description
Updates dependabot config to ignore k8s.io dependencies. These are tightly bound to transient opentelemetry dependencies and always must go hand in hand with breaking changes fixes there - otherwise each bump attempt will fail due to incompatibilities.

#### Testing
CI/CD pipeline, weekly bump should no longer contain k8s.io group.