### PR TITLE
chore: prepare release v0.140.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## vNext
 
+## v0.140.2
+- No changes
+
 ## v0.140.1
 - `k8seventgenerationprocessor` Extend the k8seventgeneration processor with parsing and exporting entity state events for Container Images and for relations between Containers and Images.
 - Updates golang to 1.25.5

--- a/extension/solarwindsextension/go.mod
+++ b/extension/solarwindsextension/go.mod
@@ -3,8 +3,8 @@ module github.com/solarwinds/solarwinds-otel-collector-contrib/extension/solarwi
 go 1.25.5
 
 require (
-	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/testutil v0.140.1
-	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/version v0.140.1
+	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/testutil v0.140.2
+	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/version v0.140.2
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.46.0
 	go.opentelemetry.io/collector/component/componenttest v0.140.0

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,4 +14,4 @@
 
 package version
 
-const Version = "0.140.1"
+const Version = "0.140.2"

--- a/processor/solarwindsprocessor/go.mod
+++ b/processor/solarwindsprocessor/go.mod
@@ -4,10 +4,10 @@ go 1.25.5
 
 require (
 	github.com/google/go-cmp v0.7.0
-	github.com/solarwinds/solarwinds-otel-collector-contrib/extension/solarwindsextension v0.140.1
-	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/attributesdecorator v0.140.1
-	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/container v0.140.1
-	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/extensionfinder v0.140.1
+	github.com/solarwinds/solarwinds-otel-collector-contrib/extension/solarwindsextension v0.140.2
+	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/attributesdecorator v0.140.2
+	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/container v0.140.2
+	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/extensionfinder v0.140.2
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.46.0
 	go.opentelemetry.io/collector/component/componenttest v0.140.0
@@ -46,7 +46,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/mostynb/go-grpc-compression v1.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/version v0.140.1 // indirect
+	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/version v0.140.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector v0.140.0 // indirect
 	go.opentelemetry.io/collector/client v1.46.0 // indirect

--- a/processor/swok8sworkloadstatusprocessor/go.mod
+++ b/processor/swok8sworkloadstatusprocessor/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/solarwinds/solarwinds-otel-collector-contrib/internal/k8sconfig v0.140.1
+	github.com/solarwinds/solarwinds-otel-collector-contrib/internal/k8sconfig v0.140.2
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/component/componentstatus v0.140.0 // indirect
 	go.opentelemetry.io/collector/component/componenttest v0.140.0

--- a/processor/swok8sworkloadtypeprocessor/go.mod
+++ b/processor/swok8sworkloadtypeprocessor/go.mod
@@ -3,7 +3,7 @@ module github.com/solarwinds/solarwinds-otel-collector-contrib/processor/swok8sw
 go 1.25.5
 
 require (
-	github.com/solarwinds/solarwinds-otel-collector-contrib/internal/k8sconfig v0.140.1
+	github.com/solarwinds/solarwinds-otel-collector-contrib/internal/k8sconfig v0.140.2
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.46.0
 	go.opentelemetry.io/collector/component/componenttest v0.140.0

--- a/receiver/swohostmetricsreceiver/go.mod
+++ b/receiver/swohostmetricsreceiver/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/go-ole/go-ole v1.3.0
 	github.com/google/go-cmp v0.7.0
 	github.com/shirou/gopsutil/v4 v4.25.11
-	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/registry v0.140.1
-	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/testutil v0.140.1
-	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/version v0.140.1
-	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/wmi v0.140.1
+	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/registry v0.140.2
+	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/testutil v0.140.2
+	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/version v0.140.2
+	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/wmi v0.140.2
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.46.0
 	go.opentelemetry.io/collector/component/componenttest v0.140.0

--- a/receiver/swok8sdiscovery/go.mod
+++ b/receiver/swok8sdiscovery/go.mod
@@ -3,7 +3,7 @@ module github.com/solarwinds/solarwinds-otel-collector-contrib/receiver/swok8sdi
 go 1.25.5
 
 require (
-	github.com/solarwinds/solarwinds-otel-collector-contrib/internal/k8sconfig v0.140.1
+	github.com/solarwinds/solarwinds-otel-collector-contrib/internal/k8sconfig v0.140.2
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.46.0
 	go.opentelemetry.io/collector/component/componenttest v0.140.0

--- a/receiver/swok8sobjectsreceiver/go.mod
+++ b/receiver/swok8sobjectsreceiver/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.140.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.140.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/xk8stest v0.140.1
-	github.com/solarwinds/solarwinds-otel-collector-contrib/internal/k8sconfig v0.140.1
+	github.com/solarwinds/solarwinds-otel-collector-contrib/internal/k8sconfig v0.140.2
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.46.0
 	go.opentelemetry.io/collector/component/componenttest v0.140.0


### PR DESCRIPTION
This PR prepares the release v0.140.2. Tested via CI/CD pipeline.