### PR TITLE
fix: #215 k8seventgenerationprocessor - Adding missing entity types to relationship state events

### DIFF
--- a/processor/k8seventgenerationprocessor/processor_test.go
+++ b/processor/k8seventgenerationprocessor/processor_test.go
@@ -86,6 +86,12 @@ func TestVulnerabilityReportManifest(t *testing.T) {
 	}
 
 	verifyVulnerabilityFinding := func(t *testing.T, attrs pcommon.Map, expectedVulnID string, expectedImageDigest string, expectedImageName string) {
+		// Verify entity types
+		actualSrcType := getStringValue(t, attrs, "otel.entity_relationship.source_entity.type")
+		assert.Equal(t, constants.EntityTypeVulnerability, actualSrcType, "Source entity type should be VulnerabilityDetail")
+		actualDestType := getStringValue(t, attrs, "otel.entity_relationship.destination_entity.type")
+		assert.Equal(t, "KubernetesContainerImage", actualDestType, "Destination entity type should be KubernetesContainerImage")
+
 		// Verify source entity ID (Vulnerability)
 		sourceIDMap := getMapValue(t, attrs, constants.AttributeOtelEntityRelationshipSourceEntityID)
 		actualVulnID := getStringValue(t, sourceIDMap, constants.AttributeVulnerabilityID)

--- a/processor/k8seventgenerationprocessor/vulnerability_log_constructor.go
+++ b/processor/k8seventgenerationprocessor/vulnerability_log_constructor.go
@@ -165,6 +165,8 @@ func transformVulnerabilitiesToFindingLogs(manifest *manifests.VulnerabilityRepo
 			attrs := lr.Attributes()
 			attrs.PutStr(constants.AttributeOtelEntityEventType, constants.EventTypeEntityRelationshipState)
 			attrs.PutStr(constants.AttributeOtelEntityRelationshipType, constants.RelationshipTypeVulnerabilityFinding)
+			attrs.PutStr(srcEntityType, constants.EntityTypeVulnerability)
+			attrs.PutStr(destEntityType, k8sContainerImageEntityType)
 
 			// Source Entity ID (Vulnerability)
 			sourceIDMap := attrs.PutEmptyMap(constants.AttributeOtelEntityRelationshipSourceEntityID)


### PR DESCRIPTION
#### Description
Followup on https://github.com/solarwinds/solarwinds-otel-collector-contrib/pull/214. 

I realised that relationship state events are sent without entity types of source and destination, so relationship was not created

**Tracking Issue:** https://github.com/solarwinds/solarwinds-otel-collector-contrib/issues/215

#### Testing
Unit tests

---

### Contribution Checklist

Please ensure your PR meets the following requirements (see [CONTRIBUTING.md](../CONTRIBUTING.md)):

**General:**
- [ ] **CHANGELOG updated** - Added entry under `## vNext` (chore PRs are a possible exemption)
- [ ] **Tests included** - Unit tests, generated tests (`mdatagen`), and/or integration tests
- [ ] **Documentation updated** - README.md with config examples and behavior description

**For new components:**
- [ ] **Codeowners** - Approver/maintainer assigned
- [ ] **Use case documented** - Reasoning, telemetry types, configuration options described in issue
- [ ] `mdatagen` has been used to autogenerate tests, update README.md and more (see [CONTRIBUTING.md](../CONTRIBUTING.md)):
- [ ] README.md contains complete configuration documentation
- [ ] **Telemetry names registered** - New metrics registered (if applicable)
> [!NOTE]  
> New components need to be added into the release (one or multiple distributions in our private releases repository).  
That can be done only after the new component has been merged & released.
