### PR TITLE
feature: #233 MQTT metric prefix

### DIFF
--- a/receiver/mqttreceiver/broker_subscription.go
+++ b/receiver/mqttreceiver/broker_subscription.go
@@ -462,14 +462,11 @@ func (sb *brokerSubscription) createMetrics(meta *subscriptionMetadata, value *s
 	rm := metrics.ResourceMetrics().At(0)
 	sm := rm.ScopeMetrics().At(0)
 	m := sm.Metrics().AppendEmpty()
-	
-	var metricName string
-	if meta.sensor != nil {
-		metricName = fmt.Sprintf("sw.otelcol.mqtt.sensor.%s", meta.metric.Name)
-	} else {
-		metricName = fmt.Sprintf("sw.otelcol.mqtt.broker.%s", meta.metric.Name)
-	}
-	m.SetName(metricName)
+    prefix := "broker"
+    if meta.sensor != nil {
+        prefix = "sensor"
+    }
+    m.SetName(fmt.Sprintf("sw.otelcol.mqtt.%s.%s", prefix, meta.metric.Name))
 	m.SetDescription(meta.metric.Desc)
 	m.SetUnit(meta.metric.Unit)
 	m.SetEmptyGauge()


### PR DESCRIPTION
#### Description
Split metrics to broker and sensor
<img width="2540" height="1150" alt="image" src="https://github.com/user-attachments/assets/72dd25f4-9268-44db-b01b-a5df5df800a8" />


**Tracking Issue:** https://github.com/solarwinds/solarwinds-otel-collector-contrib/issues/233

#### Testing
Describe what testing was performed and which tests were added.

---

### Contribution Checklist

Please ensure your PR meets the following requirements (see [CONTRIBUTING.md](../CONTRIBUTING.md)):

**General:**
- [ ] **CHANGELOG updated** - Added entry under `## vNext` (chore PRs are a possible exemption)
- [ ] **Tests included** - Unit tests, generated tests (`mdatagen`), and/or integration tests
- [ ] **Documentation updated** - README.md with config examples and behavior description

**For new components:**
- [ ] **Codeowners** - Approver/maintainer assigned
- [ ] **Use case documented** - Reasoning, telemetry types, configuration options described in issue
- [ ] `mdatagen` has been used to autogenerate tests, update README.md and more (see [CONTRIBUTING.md](../CONTRIBUTING.md)):
- [ ] README.md contains complete configuration documentation
- [ ] **Telemetry names registered** - New metrics registered (if applicable)
> [!NOTE]  
> New components need to be added into the release (one or multiple distributions in our private releases repository).  
That can be done only after the new component has been merged & released.
