### PR TITLE
add clusterUid to k8s container image

### DIFF
--- a/processor/k8seventgenerationprocessor/log_constructor.go
+++ b/processor/k8seventgenerationprocessor/log_constructor.go
@@ -138,8 +138,12 @@ func transformManifestToServiceMappingLogs(m manifests.ServiceMapping, t pcommon
 
 // transformContainersToContainerImageLogs returns a new [plog.LogRecordSlice] and appends
 // all LogRecords containing container image information from the provided Containers.
-func transformContainersToContainerImageLogs(containers map[string]manifests.Container, t pcommon.Timestamp) plog.LogRecordSlice {
+func transformContainersToContainerImageLogs(containers map[string]manifests.Container, t pcommon.Timestamp, clusterUID string) plog.LogRecordSlice {
 	lrs := plog.NewLogRecordSlice()
+
+	if clusterUID == "" {
+		return lrs
+	}
 
 	processedValidImages := make(map[imageIdentity]struct{}, len(containers))
 	for _, c := range containers {
@@ -150,6 +154,9 @@ func transformContainersToContainerImageLogs(containers map[string]manifests.Con
 			digest: extractSha256Digest(c.Image.ImageID),
 			name:   c.Image.Name,
 		}
+		if identity.digest == "" || identity.name == "" {
+			continue
+		}
 		if _, seen := processedValidImages[identity]; seen {
 			continue
 		}
@@ -157,18 +164,19 @@ func transformContainersToContainerImageLogs(containers map[string]manifests.Con
 
 		lr := lrs.AppendEmpty()
 		lr.SetObservedTimestamp(t)
-		addContainerImageAttributes(lr.Attributes(), c.Image)
+		addContainerImageAttributes(lr.Attributes(), c.Image, clusterUID)
 	}
 
 	return lrs
 }
 
 // addContainerImageAttributes sets attributes on the provided map for the given Metadata and Image.
-func addContainerImageAttributes(attrs pcommon.Map, i manifests.Image) {
+func addContainerImageAttributes(attrs pcommon.Map, i manifests.Image, clusterUID string) {
 	attrs.PutStr(otelEntityEventType, entityState)
 	attrs.PutStr(swEntityType, k8sContainerImageEntityType)
 
 	tm := attrs.PutEmptyMap(otelEntityId)
+	tm.PutStr(swK8sClusterUid, clusterUID)
 	tm.PutStr(constants.AttributeOciManifestDigest, extractSha256Digest(i.ImageID))
 	tm.PutStr(string(conventions.ContainerImageNameKey), i.Name)
 
@@ -184,7 +192,18 @@ func addContainerImageAttributes(attrs pcommon.Map, i manifests.Image) {
 func transformContainersToContainerImageRelationsLogs(containers map[string]manifests.Container, md manifests.PodMetadata, t pcommon.Timestamp, clusterUID string) plog.LogRecordSlice {
 	lrs := plog.NewLogRecordSlice()
 
+	if clusterUID == "" {
+		return lrs
+	}
+
 	for _, c := range containers {
+		if c.Image.ImageID == "" {
+			continue
+		}
+		digest := extractSha256Digest(c.Image.ImageID)
+		if digest == "" || c.Image.Name == "" {
+			continue
+		}
 		lr := lrs.AppendEmpty()
 		lr.SetObservedTimestamp(t)
 		addContainerImageRelationAttributes(lr.Attributes(), md, c, clusterUID)
@@ -208,6 +227,7 @@ func addContainerImageRelationAttributes(attrs pcommon.Map, md manifests.PodMeta
 	srcIds.PutStr(swK8sClusterUid, clusterUID)
 
 	attrs.PutStr(destEntityType, k8sContainerImageEntityType)
+	destIds.PutStr(swK8sClusterUid, clusterUID)
 	destIds.PutStr(constants.AttributeOciManifestDigest, extractSha256Digest(c.Image.ImageID))
 	destIds.PutStr(string(conventions.ContainerImageNameKey), c.Image.Name)
 
@@ -267,8 +287,13 @@ func transformContainersToContainerImageEntityLogs(containers map[string]manifes
 // transformContainersToContainerImageRelatesToLogs emits RelatesTo relationship
 // state events linking ContainerImage (source) to KubernetesContainerImage (destination)
 // for each unique {digest, name} pair in the provided containers.
-func transformContainersToContainerImageRelatesToLogs(containers map[string]manifests.Container, t pcommon.Timestamp, logger *zap.Logger) plog.LogRecordSlice {
+func transformContainersToContainerImageRelatesToLogs(containers map[string]manifests.Container, t pcommon.Timestamp, clusterUID string, logger *zap.Logger) plog.LogRecordSlice {
 	lrs := plog.NewLogRecordSlice()
+
+	if clusterUID == "" {
+		return lrs
+	}
+
 	seenIdentities := make(map[imageIdentity]struct{}, len(containers))
 
 	for _, c := range containers {
@@ -284,6 +309,13 @@ func transformContainersToContainerImageRelatesToLogs(containers map[string]mani
 			logger.Warn("skipping container with malformed ImageID for RelatesTo relationship",
 				zap.String("container", c.Name),
 				zap.String("imageID", c.Image.ImageID),
+			)
+			continue
+		}
+
+		if c.Image.Name == "" {
+			logger.Warn("skipping container with empty image name for RelatesTo relationship",
+				zap.String("container", c.Name),
 			)
 			continue
 		}
@@ -305,9 +337,10 @@ func transformContainersToContainerImageRelatesToLogs(containers map[string]mani
 		srcIds := attrs.PutEmptyMap(relationshipSrcEntityIds)
 		srcIds.PutStr(constants.AttributeOciManifestDigest, digest)
 
-		// Destination: KubernetesContainerImage identified by {digest, name}
+		// Destination: KubernetesContainerImage identified by {clusterUid, digest, name}
 		attrs.PutStr(destEntityType, k8sContainerImageEntityType)
 		destIds := attrs.PutEmptyMap(relationshipDestEntityIds)
+		destIds.PutStr(swK8sClusterUid, clusterUID)
 		destIds.PutStr(constants.AttributeOciManifestDigest, digest)
 		destIds.PutStr(string(conventions.ContainerImageNameKey), c.Image.Name)
 	}

--- a/processor/k8seventgenerationprocessor/log_constructor_test.go
+++ b/processor/k8seventgenerationprocessor/log_constructor_test.go
@@ -448,7 +448,7 @@ func TestTransformContainersToContainerImageRelatesToLogs(t *testing.T) {
 			},
 		}
 
-		result := transformContainersToContainerImageRelatesToLogs(containers, timestamp, zap.NewNop())
+		result := transformContainersToContainerImageRelatesToLogs(containers, timestamp, "test-cluster-uid", zap.NewNop())
 
 		require.Equal(t, 1, result.Len())
 		lr := result.At(0)
@@ -472,7 +472,7 @@ func TestTransformContainersToContainerImageRelatesToLogs(t *testing.T) {
 			},
 		}
 
-		result := transformContainersToContainerImageRelatesToLogs(containers, timestamp, zap.NewNop())
+		result := transformContainersToContainerImageRelatesToLogs(containers, timestamp, "test-cluster-uid", zap.NewNop())
 
 		assert.Equal(t, 1, result.Len(), "identical {digest, name} pair should emit one relationship")
 	})
@@ -490,7 +490,7 @@ func TestTransformContainersToContainerImageRelatesToLogs(t *testing.T) {
 			},
 		}
 
-		result := transformContainersToContainerImageRelatesToLogs(containers, timestamp, zap.NewNop())
+		result := transformContainersToContainerImageRelatesToLogs(containers, timestamp, "test-cluster-uid", zap.NewNop())
 
 		assert.Equal(t, 2, result.Len(), "same digest with different names should emit two relationships")
 
@@ -511,12 +511,13 @@ func TestTransformContainersToContainerImageRelatesToLogs(t *testing.T) {
 			},
 		}
 
-		result := transformContainersToContainerImageRelatesToLogs(containers, timestamp, zap.NewNop())
+		result := transformContainersToContainerImageRelatesToLogs(containers, timestamp, "test-cluster-uid", zap.NewNop())
 
 		assert.Equal(t, 0, result.Len(), "container with empty ImageID should be skipped")
 	})
 
-	t.Run("correct source and destination entity types and IDs", func(t *testing.T) {
+	// T009: supply clusterUID and assert sw.k8s.cluster.uid is present in destination entity IDs.
+	t.Run("correct source and destination entity types and IDs with clusterUID", func(t *testing.T) {
 		containers := map[string]manifests.Container{
 			"nginx": {
 				Name:  "nginx",
@@ -524,7 +525,7 @@ func TestTransformContainersToContainerImageRelatesToLogs(t *testing.T) {
 			},
 		}
 
-		result := transformContainersToContainerImageRelatesToLogs(containers, timestamp, zap.NewNop())
+		result := transformContainersToContainerImageRelatesToLogs(containers, timestamp, "test-cluster-uid", zap.NewNop())
 
 		require.Equal(t, 1, result.Len())
 		attrs := result.At(0).Attributes()
@@ -535,12 +536,29 @@ func TestTransformContainersToContainerImageRelatesToLogs(t *testing.T) {
 		assert.Equal(t, 1, srcIds.Len(), "source entity should have only oci.manifest.digest")
 		assert.Equal(t, validDigest, getStringValue(t, srcIds, constants.AttributeOciManifestDigest))
 
-		// Destination: KubernetesContainerImage with {oci.manifest.digest, container.image.name}
+		// Destination: KubernetesContainerImage with {sw.k8s.cluster.uid, oci.manifest.digest, container.image.name}
 		assert.Equal(t, k8sContainerImageEntityType, getStringValue(t, attrs, destEntityType))
 		destIds := getMapValue(t, attrs, relationshipDestEntityIds)
-		assert.Equal(t, 2, destIds.Len(), "destination entity should have oci.manifest.digest and container.image.name")
+		assert.Equal(t, 3, destIds.Len(), "destination entity should have sw.k8s.cluster.uid, oci.manifest.digest and container.image.name")
+		assert.Equal(t, "test-cluster-uid", getStringValue(t, destIds, "sw.k8s.cluster.uid"),
+			"RelatesTo destination ID must include sw.k8s.cluster.uid")
 		assert.Equal(t, validDigest, getStringValue(t, destIds, constants.AttributeOciManifestDigest))
 		assert.Equal(t, "docker.io/library/nginx", getStringValue(t, destIds, "container.image.name"))
+	})
+
+	// T010: skips records when clusterUID is empty.
+	t.Run("skips records when clusterUID is empty", func(t *testing.T) {
+		containers := map[string]manifests.Container{
+			"nginx": {
+				Name:  "nginx",
+				Image: manifests.Image{ImageID: validImageID, Name: "docker.io/library/nginx", Tag: "1.25"},
+			},
+		}
+
+		result := transformContainersToContainerImageRelatesToLogs(containers, timestamp, "", zap.NewNop())
+
+		assert.Equal(t, 0, result.Len(),
+			"RelatesTo relationship emission must be skipped when clusterUID is empty")
 	})
 }
 
@@ -579,7 +597,7 @@ func TestTransformContainersToContainerImagePartialFailure(t *testing.T) {
 		ids := getMapValue(t, entityResult.At(0).Attributes(), otelEntityId)
 		assert.Equal(t, validDigest, getStringValue(t, ids, constants.AttributeOciManifestDigest))
 
-		relResult := transformContainersToContainerImageRelatesToLogs(containers, timestamp, logger)
+		relResult := transformContainersToContainerImageRelatesToLogs(containers, timestamp, "test-cluster-uid", logger)
 
 		assert.Equal(t, 1, relResult.Len(), "only valid container should emit relationship")
 
@@ -597,5 +615,97 @@ func TestTransformContainersToContainerImagePartialFailure(t *testing.T) {
 			}
 		}
 		assert.True(t, foundMalformedWarning, "should log a warning with container name 'bad-container' and its ImageID")
+	})
+}
+
+// TestTransformContainersToContainerImageLogs tests the KubernetesContainerImage entity state event path.
+// T005: entity ID map must include sw.k8s.cluster.uid when clusterUID is provided.
+// T006: function must skip (return zero records) when clusterUID is empty.
+func TestTransformContainersToContainerImageLogs(t *testing.T) {
+	const (
+		validImageID = "docker://sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+		validDigest  = "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+		clusterUID   = "test-cluster-uid"
+	)
+
+	t.Run("entity ID includes sw.k8s.cluster.uid (T005)", func(t *testing.T) {
+		containers := map[string]manifests.Container{
+			"nginx": {
+				Name:  "nginx",
+				Image: manifests.Image{ImageID: validImageID, Name: "docker.io/library/nginx", Tag: "1.25"},
+			},
+		}
+
+		result := transformContainersToContainerImageLogs(containers, timestamp, clusterUID)
+
+		require.Equal(t, 1, result.Len())
+		ids := getMapValue(t, result.At(0).Attributes(), otelEntityId)
+		assert.Equal(t, clusterUID, getStringValue(t, ids, "sw.k8s.cluster.uid"),
+			"KubernetesContainerImage entity ID must include sw.k8s.cluster.uid")
+		assert.Equal(t, validDigest, getStringValue(t, ids, constants.AttributeOciManifestDigest))
+		assert.Equal(t, "docker.io/library/nginx", getStringValue(t, ids, "container.image.name"))
+	})
+
+	t.Run("skips all records when clusterUID is empty (T006)", func(t *testing.T) {
+		containers := map[string]manifests.Container{
+			"nginx": {
+				Name:  "nginx",
+				Image: manifests.Image{ImageID: validImageID, Name: "docker.io/library/nginx", Tag: "1.25"},
+			},
+		}
+
+		result := transformContainersToContainerImageLogs(containers, timestamp, "")
+
+		assert.Equal(t, 0, result.Len(),
+			"KubernetesContainerImage entity emission must be skipped when clusterUID is empty")
+	})
+}
+
+// TestTransformContainersToContainerImageRelationsLogs tests the KubernetesResourceUsesImage relationship path.
+// T007: destination entity ID must include sw.k8s.cluster.uid when clusterUID is provided.
+// T008: function must skip records when clusterUID is empty.
+func TestTransformContainersToContainerImageRelationsLogs(t *testing.T) {
+	const (
+		validImageID = "docker://sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+		validDigest  = "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+		clusterUID   = "test-cluster-uid"
+	)
+
+	md := manifests.PodMetadata{
+		Name:      "test-pod",
+		Namespace: "test-namespace",
+	}
+
+	t.Run("destination entity ID includes sw.k8s.cluster.uid (T007)", func(t *testing.T) {
+		containers := map[string]manifests.Container{
+			"nginx": {
+				Name:  "nginx",
+				Image: manifests.Image{ImageID: validImageID, Name: "docker.io/library/nginx", Tag: "1.25"},
+			},
+		}
+
+		result := transformContainersToContainerImageRelationsLogs(containers, md, timestamp, clusterUID)
+
+		require.Equal(t, 1, result.Len())
+		attrs := result.At(0).Attributes()
+		destIds := getMapValue(t, attrs, relationshipDestEntityIds)
+		assert.Equal(t, clusterUID, getStringValue(t, destIds, "sw.k8s.cluster.uid"),
+			"KubernetesResourceUsesImage destination entity ID must include sw.k8s.cluster.uid")
+		assert.Equal(t, validDigest, getStringValue(t, destIds, constants.AttributeOciManifestDigest))
+		assert.Equal(t, "docker.io/library/nginx", getStringValue(t, destIds, "container.image.name"))
+	})
+
+	t.Run("skips records when clusterUID is empty (T008)", func(t *testing.T) {
+		containers := map[string]manifests.Container{
+			"nginx": {
+				Name:  "nginx",
+				Image: manifests.Image{ImageID: validImageID, Name: "docker.io/library/nginx", Tag: "1.25"},
+			},
+		}
+
+		result := transformContainersToContainerImageRelationsLogs(containers, md, timestamp, "")
+
+		assert.Equal(t, 0, result.Len(),
+			"KubernetesResourceUsesImage relationship emission must be skipped when clusterUID is empty")
 	})
 }

--- a/processor/k8seventgenerationprocessor/processor.go
+++ b/processor/k8seventgenerationprocessor/processor.go
@@ -88,9 +88,9 @@ func (cp *k8seventgenerationprocessor) generateLogRecords(resCh <-chan result, e
 			containers.MoveAndAppendTo(entityStateEvents)
 			containerImageEntities := transformContainersToContainerImageEntityLogs(manifestContainers, res.Timestamp, cp.logger)
 			containerImageEntities.MoveAndAppendTo(entityStateEvents)
-			containerImageRelates := transformContainersToContainerImageRelatesToLogs(manifestContainers, res.Timestamp, cp.logger)
+			containerImageRelates := transformContainersToContainerImageRelatesToLogs(manifestContainers, res.Timestamp, res.ClusterUID, cp.logger)
 			containerImageRelates.MoveAndAppendTo(entityStateEvents)
-			containerImages := transformContainersToContainerImageLogs(manifestContainers, res.Timestamp)
+			containerImages := transformContainersToContainerImageLogs(manifestContainers, res.Timestamp, res.ClusterUID)
 			containerImages.MoveAndAppendTo(entityStateEvents)
 			containerImageRelations := transformContainersToContainerImageRelationsLogs(manifestContainers, m.Metadata, res.Timestamp, res.ClusterUID)
 			containerImageRelations.MoveAndAppendTo(entityStateEvents)
@@ -102,7 +102,7 @@ func (cp *k8seventgenerationprocessor) generateLogRecords(resCh <-chan result, e
 			entities.MoveAndAppendTo(entityStateEvents)
 			findingRels := transformVulnerabilitiesToFindingLogs(m, res.Timestamp, res.ClusterUID)
 			findingRels.MoveAndAppendTo(entityStateEvents)
-			containerImage := transformVulnerabilityReportToContainerImageLog(m, res.Timestamp)
+			containerImage := transformVulnerabilityReportToContainerImageLog(m, res.Timestamp, res.ClusterUID)
 			containerImage.MoveAndAppendTo(entityStateEvents)
 		}
 	}

--- a/processor/k8seventgenerationprocessor/processor_test.go
+++ b/processor/k8seventgenerationprocessor/processor_test.go
@@ -71,8 +71,10 @@ func TestVulnerabilityReportManifest(t *testing.T) {
 		assert.True(t, isSlice, "vulnerability.reference should be an array")
 	}
 
-	verifyContainerImage := func(t *testing.T, attrs pcommon.Map, expectedImageID string, expectedImageName string, expectedImageTag string) {
+	verifyContainerImage := func(t *testing.T, attrs pcommon.Map, expectedClusterUID string, expectedImageID string, expectedImageName string, expectedImageTag string) {
 		ids := getMapValue(t, attrs, "otel.entity.id")
+		assert.Equal(t, expectedClusterUID, getStringValue(t, ids, "sw.k8s.cluster.uid"),
+			"KubernetesContainerImage entity ID must contain sw.k8s.cluster.uid")
 		assert.Equal(t, expectedImageID, getStringValue(t, ids, constants.AttributeOciManifestDigest))
 		assert.Equal(t, expectedImageName, getStringValue(t, ids, "container.image.name"))
 
@@ -175,7 +177,7 @@ func TestVulnerabilityReportManifest(t *testing.T) {
 					}
 				} else if entityType == "KubernetesContainerImage" {
 					containerImageCount++
-					verifyContainerImage(t, attrs, "sha256:83c025f0faa6799fab6645102a98138e39a9a7db2be3bc792c79d72659b1805d", "registry.k8s.io/kube-proxy", "v1.32.2")
+					verifyContainerImage(t, attrs, "test-cluster-uid", "sha256:83c025f0faa6799fab6645102a98138e39a9a7db2be3bc792c79d72659b1805d", "registry.k8s.io/kube-proxy", "v1.32.2")
 				}
 			} else if eventType == constants.EventTypeEntityRelationshipState {
 				relType := getStringValue(t, attrs, constants.AttributeOtelEntityRelationshipType)
@@ -264,13 +266,10 @@ func TestEmptyTagScenario(t *testing.T) {
 				entityType := getStringValue(t, attrs, "otel.entity.type")
 				if entityType == "KubernetesContainerImage" {
 					foundImage = true
-					verifyEmptyTagArray(t, attrs)
-					ids := getMapValue(t, attrs, "otel.entity.id")
-					assert.Equal(t, "", getStringValue(t, ids, "container.image.name"))
 				}
 			}
 		}
-		assert.True(t, foundImage, "Should have found a container image entity")
+		assert.False(t, foundImage, "KubernetesContainerImage entity must not be emitted when container.image.name is empty")
 	})
 
 	t.Run("VulnerabilityReportWithEmptyTag", func(t *testing.T) {
@@ -283,7 +282,7 @@ func TestEmptyTagScenario(t *testing.T) {
 			},
 			"report": {
 				"artifact": {
-					"digest": "sha256:digest456",
+					"digest": "sha256:83c025f0faa6799fab6645102a98138e39a9a7db2be3bc792c79d72659b1805d",
 					"repository": "test-repo",
 					"tag": ""
 				},
@@ -723,6 +722,10 @@ func TestPodManifestEmitsContainerImageAndRelatesToEvents(t *testing.T) {
 				assert.True(t, hasDigest, "ContainerImage ID should contain oci.manifest.digest")
 			case "KubernetesContainerImage":
 				k8sContainerImageCount++
+				// T014b: verify entity ID contains sw.k8s.cluster.uid
+				ids := getMapValue(t, attrs, "otel.entity.id")
+				assert.Equal(t, "test-cluster-uid", getStringValue(t, ids, "sw.k8s.cluster.uid"),
+					"KubernetesContainerImage entity ID must contain sw.k8s.cluster.uid")
 			case "KubernetesContainer":
 				k8sContainerCount++
 			}
@@ -748,4 +751,47 @@ func TestPodManifestEmitsContainerImageAndRelatesToEvents(t *testing.T) {
 	assert.GreaterOrEqual(t, k8sContainerImageCount, 1, "should still emit KubernetesContainerImage entities")
 	assert.GreaterOrEqual(t, k8sResourceUsesImageCount, 1, "should still emit KubernetesResourceUsesImage relationships")
 	assert.GreaterOrEqual(t, k8sContainerCount, 1, "should still emit KubernetesContainer entities")
+}
+
+// TestPodManifestWithoutClusterUIDEmitsNoKubernetesContainerImageEvents verifies that
+// when the resource log does not carry the sw.k8s.cluster.uid resource attribute,
+// no KubernetesContainerImage entity state events are emitted (skip-on-missing invariant).
+// T014b (negative path)
+func TestPodManifestWithoutClusterUIDEmitsNoKubernetesContainerImageEvents(t *testing.T) {
+	podManifestNoClusterUID := `{"apiVersion":"v1","kind":"Pod","metadata":{"annotations":{},"name":"test-pod","namespace":"test-namespace"},"spec":{"containers":[{"image":"nginx:1.25","name":"nginx"}]},"status":{"containerStatuses":[{"containerID":"containerd://abc123","image":"nginx:1.25","imageID":"docker://sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4","name":"nginx","state":{"running":{}}}]}}`
+
+	// Build a log WITHOUT sw.k8s.cluster.uid resource attribute (unlike generateManifestLogs which always sets it).
+	l := generateLogs()
+	rl := l.ResourceLogs().At(0)
+	rl.Resource().Attributes().PutBool("ORIGINAL_LOG", true)
+	sl := rl.ScopeLogs().At(0)
+	lr := sl.LogRecords().AppendEmpty()
+	lr.Attributes().PutStr("k8s.object.kind", "Pod")
+	lr.Body().SetStr(podManifestNoClusterUID)
+	lr.SetObservedTimestamp(timestamp)
+
+	consumer, err := startAndConsumeLogs(t, l)
+	require.NoError(t, err)
+
+	result := consumer.AllLogs()
+	require.Len(t, result, 1)
+
+	// Find entity state event resource log (if any)
+	k8sContainerImageCount := 0
+	for i := 0; i < result[0].ResourceLogs().Len(); i++ {
+		rl := result[0].ResourceLogs().At(i)
+		if v, ok := rl.Resource().Attributes().Get("sw.k8s.log.type"); ok && v.AsString() == "entitystateevent" {
+			logRecords := rl.ScopeLogs().At(0).LogRecords()
+			for j := 0; j < logRecords.Len(); j++ {
+				attrs := logRecords.At(j).Attributes()
+				if getStringValue(t, attrs, "otel.entity.event.type") == "entity_state" &&
+					getStringValue(t, attrs, "otel.entity.type") == "KubernetesContainerImage" {
+					k8sContainerImageCount++
+				}
+			}
+		}
+	}
+
+	assert.Equal(t, 0, k8sContainerImageCount,
+		"should emit no KubernetesContainerImage events when sw.k8s.cluster.uid resource attribute is absent")
 }

--- a/processor/k8seventgenerationprocessor/vulnerability_log_constructor.go
+++ b/processor/k8seventgenerationprocessor/vulnerability_log_constructor.go
@@ -264,14 +264,26 @@ func transformVulnerabilitiesToFindingLogs(manifest *manifests.VulnerabilityRepo
 		return logs
 	}
 
+	digest := extractSha256Digest(manifest.Report.Artifact.Digest)
+	if digest == "" || !isValidDigest(digest) {
+		return logs
+	}
+
+	normalizedName := normalizeVulnerabilityReportImage(manifest.Report.Registry.Server, manifest.Report.Artifact.Repository, manifest.Report.Artifact.Tag)
+	if normalizedName == "" {
+		return logs
+	}
+
 	for _, v := range manifest.Report.Vulnerabilities {
 		if v.Resource == "" {
 			continue
 		}
 
+		if clusterUID == "" {
+			continue
+		}
+
 		canonicalID := canonicalizeVulnerabilityID(&v)
-		digest := extractSha256Digest(manifest.Report.Artifact.Digest)
-		normalizedName := normalizeVulnerabilityReportImage(manifest.Report.Registry.Server, manifest.Report.Artifact.Repository, manifest.Report.Artifact.Tag)
 
 		lr := logs.AppendEmpty()
 		lr.SetTimestamp(timestamp)
@@ -289,8 +301,9 @@ func transformVulnerabilitiesToFindingLogs(manifest *manifests.VulnerabilityRepo
 		sourceIDMap.PutStr(constants.AttributeVulnerabilityResource, v.Resource)
 		sourceIDMap.PutStr(constants.AttributeVulnerabilityInstalledVersion, v.InstalledVersion)
 
-		// Destination: KubernetesContainerImage
+		// Destination: KubernetesContainerImage with 3-part key
 		destIDMap := attrs.PutEmptyMap(constants.AttributeOtelEntityRelationshipDestinationEntityID)
+		destIDMap.PutStr(swK8sClusterUid, clusterUID)
 		destIDMap.PutStr(constants.AttributeOciManifestDigest, digest)
 		destIDMap.PutStr(string(conventions.ContainerImageNameKey), normalizedName)
 
@@ -304,10 +317,24 @@ func transformVulnerabilitiesToFindingLogs(manifest *manifests.VulnerabilityRepo
 	return logs
 }
 
-func transformVulnerabilityReportToContainerImageLog(manifest *manifests.VulnerabilityReportManifest, t pcommon.Timestamp) plog.LogRecordSlice {
+func transformVulnerabilityReportToContainerImageLog(manifest *manifests.VulnerabilityReportManifest, t pcommon.Timestamp, clusterUID string) plog.LogRecordSlice {
 	lrs := plog.NewLogRecordSlice()
 
+	if clusterUID == "" {
+		return lrs
+	}
+
 	if manifest.Report.Artifact.Digest == "" {
+		return lrs
+	}
+
+	digest := extractSha256Digest(manifest.Report.Artifact.Digest)
+	if digest == "" || !isValidDigest(digest) {
+		return lrs
+	}
+
+	normalizedName := normalizeVulnerabilityReportImage(manifest.Report.Registry.Server, manifest.Report.Artifact.Repository, manifest.Report.Artifact.Tag)
+	if normalizedName == "" {
 		return lrs
 	}
 
@@ -319,8 +346,8 @@ func transformVulnerabilityReportToContainerImageLog(manifest *manifests.Vulnera
 	attrs.PutStr(swEntityType, k8sContainerImageEntityType)
 
 	tm := attrs.PutEmptyMap(otelEntityId)
-	tm.PutStr(constants.AttributeOciManifestDigest, extractSha256Digest(manifest.Report.Artifact.Digest))
-	normalizedName := normalizeVulnerabilityReportImage(manifest.Report.Registry.Server, manifest.Report.Artifact.Repository, manifest.Report.Artifact.Tag)
+	tm.PutStr(swK8sClusterUid, clusterUID)
+	tm.PutStr(constants.AttributeOciManifestDigest, digest)
 	tm.PutStr(string(conventions.ContainerImageNameKey), normalizedName)
 
 	entityAttrs := attrs.PutEmptyMap(constants.AttributeOtelEntityAttributes)

--- a/processor/k8seventgenerationprocessor/vulnerability_log_constructor_test.go
+++ b/processor/k8seventgenerationprocessor/vulnerability_log_constructor_test.go
@@ -483,3 +483,99 @@ func TestEnvironmentalScoreFromScoreField(t *testing.T) {
 		})
 	}
 }
+
+func newVulnerabilityReportManifest() *manifests.VulnerabilityReportManifest {
+	return &manifests.VulnerabilityReportManifest{
+		Report: manifests.VulnerabilityReportReport{
+			Artifact: manifests.VulnerabilityReportArtifact{
+				Digest:     "sha256:83c025f0faa6799fab6645102a98138e39a9a7db2be3bc792c79d72659b1805d",
+				Repository: "kube-proxy",
+				Tag:        "v1.32.2",
+			},
+			Registry: manifests.VulnerabilityReportRegistry{
+				Server: "registry.k8s.io",
+			},
+			Scanner: manifests.VulnerabilityReportScanner{
+				Name:    "Trivy",
+				Vendor:  "Aqua Security",
+				Version: "0.66.0",
+			},
+			Vulnerabilities: []manifests.Vulnerability{
+				{
+					VulnerabilityID:  "CVE-2024-TEST",
+					Resource:         "libtest",
+					InstalledVersion: "1.0.0",
+					Severity:         "HIGH",
+					CVSS: manifests.CVSS{
+						NVD: manifests.CVSSSource{V3Score: 7.5},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestTransformVulnerabilityReportToContainerImageLog tests the KubernetesContainerImage entity
+// emitted from the vulnerability report path.
+// T011: entity ID must include sw.k8s.cluster.uid when clusterUID is provided.
+// T012: function must return zero records when clusterUID is empty.
+func TestTransformVulnerabilityReportToContainerImageLog(t *testing.T) {
+	const clusterUID = "test-cluster-uid"
+
+	t.Run("entity ID includes sw.k8s.cluster.uid (T011)", func(t *testing.T) {
+		manifest := newVulnerabilityReportManifest()
+		ts := pcommon.NewTimestampFromTime(time.Now())
+
+		result := transformVulnerabilityReportToContainerImageLog(manifest, ts, clusterUID)
+
+		require.Equal(t, 1, result.Len())
+		ids, exists := result.At(0).Attributes().Get("otel.entity.id")
+		require.True(t, exists, "otel.entity.id must be present")
+		idsMap := ids.Map()
+		assert.Equal(t, clusterUID, getStringFromMap(idsMap, "sw.k8s.cluster.uid"),
+			"KubernetesContainerImage entity ID from vulnerability path must include sw.k8s.cluster.uid")
+	})
+
+	t.Run("returns zero records when clusterUID is empty (T012)", func(t *testing.T) {
+		manifest := newVulnerabilityReportManifest()
+		ts := pcommon.NewTimestampFromTime(time.Now())
+
+		result := transformVulnerabilityReportToContainerImageLog(manifest, ts, "")
+
+		assert.Equal(t, 0, result.Len(),
+			"KubernetesContainerImage entity from vulnerability path must be skipped when clusterUID is empty")
+	})
+}
+
+// TestTransformVulnerabilitiesToFindingLogs tests the VulnerabilityFinding relationship path.
+// T013: destination entity ID must include sw.k8s.cluster.uid when clusterUID is provided.
+// T014: individual finding records must be skipped when clusterUID is empty.
+func TestTransformVulnerabilitiesToFindingLogs(t *testing.T) {
+	const clusterUID = "test-cluster-uid"
+
+	t.Run("destination entity ID includes sw.k8s.cluster.uid (T013)", func(t *testing.T) {
+		manifest := newVulnerabilityReportManifest()
+		ts := pcommon.NewTimestampFromTime(time.Now())
+
+		result := transformVulnerabilitiesToFindingLogs(manifest, ts, clusterUID)
+
+		require.GreaterOrEqual(t, result.Len(), 1, "should emit at least one finding relationship")
+		for i := 0; i < result.Len(); i++ {
+			attrs := result.At(i).Attributes()
+			destIDs, exists := attrs.Get(constants.AttributeOtelEntityRelationshipDestinationEntityID)
+			require.True(t, exists, "destination entity ID must be present on finding record")
+			assert.Equal(t, clusterUID, getStringFromMap(destIDs.Map(), "sw.k8s.cluster.uid"),
+				"VulnerabilityFinding destination entity ID must include sw.k8s.cluster.uid (record %d)", i)
+		}
+	})
+
+	t.Run("skips all finding records when clusterUID is empty (T014)", func(t *testing.T) {
+		manifest := newVulnerabilityReportManifest()
+		ts := pcommon.NewTimestampFromTime(time.Now())
+
+		result := transformVulnerabilitiesToFindingLogs(manifest, ts, "")
+
+		assert.Equal(t, 0, result.Len(),
+			"VulnerabilityFinding records must be skipped when clusterUID is empty")
+	})
+}


### PR DESCRIPTION
#### Description
Add clusterUid to events generating k8s container image entities

**Tracking Issue:** https://github.com/solarwinds/solarwinds-otel-collector-contrib/issues/XXXX

#### Testing
Describe what testing was performed and which tests were added.

---

### Contribution Checklist

Please ensure your PR meets the following requirements (see [CONTRIBUTING.md](../CONTRIBUTING.md)):

**General:**
- [ ] **CHANGELOG updated** - Added entry under `## vNext` (chore PRs are a possible exemption)
- [ ] **Tests included** - Unit tests, generated tests (`mdatagen`), and/or integration tests
- [ ] **Documentation updated** - README.md with config examples and behavior description

**For new components:**
- [ ] **Codeowners** - Approver/maintainer assigned
- [ ] **Use case documented** - Reasoning, telemetry types, configuration options described in issue
- [ ] `mdatagen` has been used to autogenerate tests, update README.md and more (see [CONTRIBUTING.md](../CONTRIBUTING.md)):
- [ ] README.md contains complete configuration documentation
- [ ] **Telemetry names registered** - New metrics registered (if applicable)
> [!NOTE]  
> New components need to be added into the release (one or multiple distributions in our private releases repository).  
That can be done only after the new component has been merged & released.
