### PR TITLE
ci: add GitHub STS trust policy for releases pipeline

### DIFF
--- a/.github/sts/cci-releases-pipeline.sts.yaml
+++ b/.github/sts/cci-releases-pipeline.sts.yaml
@@ -1,0 +1,5 @@
+issuer: https://oidc.circleci.com/org/a942ef45-8daa-4e55-934d-370a708aabc8
+subject_pattern: org/solarwinds-cloud/project/solarwinds-otel-collector-releases/user/.*
+permissions:
+  contents: write
+  pull_requests: write


### PR DESCRIPTION
#### Description
Adds `.github/sts/cci-releases-pipeline.sts.yaml` trust policy to allow the CircleCI release pipeline in `solarwinds-cloud/solarwinds-otel-collector-releases` to obtain short-lived GitHub tokens via STS federation, replacing the need for long-lived PATs.

#### Testing
Run release wave 1

