### PR TITLE
feature: #146 Invert direction of the `DiscoveredBy` relation in the `swok8sdiscovery` receiver.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## vNext
 
+### Breaking Changes
+- ⚠️ **swok8sdiscovery receiver** : The `DiscoveredBy` relation now has inverted direction.
+
 ## v0.150.4
 - **Added** `swootelentityrefprocessor` for manipulating EntityRefs
 

--- a/receiver/swok8sdiscovery/discovery_domains.go
+++ b/receiver/swok8sdiscovery/discovery_domains.go
@@ -26,7 +26,7 @@ import (
 )
 
 // discoverDatabasesByDomains matches ExternalName services to domain rules.
-func (r *swok8sdiscoveryReceiver) discoverDatabasesByDomains(ctx context.Context, pods []corev1.Pod, services []corev1.Service) {
+func (r *swok8sdiscoveryReceiver) discoverDatabasesByDomains(ctx context.Context, services []corev1.Service) {
 	if r.config.Database == nil || len(r.config.Database.DomainRules) == 0 {
 		r.setting.Logger.Info("Domain-based database discovery skipped",
 			zap.Bool("database_config_present", r.config.Database != nil),

--- a/receiver/swok8sdiscovery/events.go
+++ b/receiver/swok8sdiscovery/events.go
@@ -116,16 +116,16 @@ func (r *swok8sdiscoveryReceiver) publishRelationShip(ctx context.Context, ev da
 	attrs.PutStr(otelEntityRelationType, discoveredRelationshipType)
 
 	// source entity
-	attrs.PutStr(otelEntityRelationSourceType, "Kubernetes"+ev.WorkloadKind)
+	attrs.PutStr(otelEntityRelationSourceType, discoveredDatabaseEntityType)
 	src_ids := attrs.PutEmptyMap(otelEntityRelationSourceID)
-	src_ids.PutStr("k8s."+strings.ToLower(ev.WorkloadKind)+".name", ev.WorkloadName)
-	src_ids.PutStr(k8sNamespace, ev.Namespace)
-	src_ids.PutStr(swK8sClusterUid, r.clusterUid)
+	dbKeys.CopyTo(src_ids)
 
 	// destination entity
-	attrs.PutStr(otelEntityRelationDestinationType, discoveredDatabaseEntityType)
+	attrs.PutStr(otelEntityRelationDestinationType, "Kubernetes"+ev.WorkloadKind)
 	dst_ids := attrs.PutEmptyMap(otelEntityRelationDestinationID)
-	dbKeys.CopyTo(dst_ids)
+	dst_ids.PutStr("k8s."+strings.ToLower(ev.WorkloadKind)+".name", ev.WorkloadName)
+	dst_ids.PutStr(k8sNamespace, ev.Namespace)
+	dst_ids.PutStr(swK8sClusterUid, r.clusterUid)
 
 	return r.consumer.ConsumeLogs(ctx, logs)
 }

--- a/receiver/swok8sdiscovery/receiver.go
+++ b/receiver/swok8sdiscovery/receiver.go
@@ -99,7 +99,7 @@ func (r *swok8sdiscoveryReceiver) performDiscoveryCycle(ctx context.Context) {
 
 	var wg sync.WaitGroup
 	wg.Go(func() { r.discoverDatabasesByImages(ctx, pods, services) })
-	wg.Go(func() { r.discoverDatabasesByDomains(ctx, pods, services) })
+	wg.Go(func() { r.discoverDatabasesByDomains(ctx, services) })
 
 	wg.Wait()
 	if r.cycleCallback != nil {

--- a/receiver/swok8sdiscovery/receiver_test.go
+++ b/receiver/swok8sdiscovery/receiver_test.go
@@ -92,7 +92,7 @@ func runImageCycle(t *testing.T, cfg *Config, objects ...runtime.Object) []plog.
 	require.NoError(t, rec.Start(ctx, componenttest.NewNopHost()))
 
 	<-done
-	rec.Shutdown(ctx)
+	require.NoError(t, rec.Shutdown(ctx))
 
 	return cap.logs
 }
@@ -183,10 +183,10 @@ func TestDomainDiscovery_SingleMatch(t *testing.T) {
 
 	relAttrs := collectAttrs(logs, otelEntityEventType, relationshipState)
 	require.Len(t, relAttrs, 1, "expected relationship when workload resolved")
-	checkAttr(t, relAttrs[0], otelEntityRelationSourceType, "KubernetesService")
-	srcIDs := getAttrMap(t, relAttrs[0], otelEntityRelationSourceID)
-	checkAttr(t, srcIDs, "k8s.service.name", "redis-ext")
-	checkAttr(t, srcIDs, k8sNamespace, "db")
+	checkAttr(t, relAttrs[0], otelEntityRelationDestinationType, "KubernetesService")
+	destIDs := getAttrMap(t, relAttrs[0], otelEntityRelationDestinationID)
+	checkAttr(t, destIDs, "k8s.service.name", "redis-ext")
+	checkAttr(t, destIDs, k8sNamespace, "db")
 }
 
 func TestDomainDiscovery_SingleMatchCustomPort(t *testing.T) {
@@ -335,16 +335,16 @@ func TestImageDiscovery_SingleMatch(t *testing.T) {
 	relationAttrs := collectAttrs(logs, otelEntityEventType, relationshipState)
 	require.Len(t, relationAttrs, 1)
 	checkAttr(t, relationAttrs[0], otelEntityRelationType, discoveredRelationshipType)
-	checkAttr(t, relationAttrs[0], otelEntityRelationSourceType, "KubernetesDaemonSet")
-	source_ids := getAttrMap(t, relationAttrs[0], otelEntityRelationSourceID)
-	checkAttr(t, source_ids, "k8s.daemonset.name", "mongo-ds")
-	checkAttr(t, source_ids, k8sNamespace, "db")
-	checkAttr(t, source_ids, swK8sClusterUid, testClusterUid)
-
-	checkAttr(t, relationAttrs[0], otelEntityRelationDestinationType, discoveredDatabaseEntityType)
+	checkAttr(t, relationAttrs[0], otelEntityRelationDestinationType, "KubernetesDaemonSet")
 	dst_ids := getAttrMap(t, relationAttrs[0], otelEntityRelationDestinationID)
-	checkAttr(t, dst_ids, swDiscoveryDbAddress, "mongo-svc.db:27017")
-	checkAttr(t, dst_ids, swDiscoveryDbType, "mongo")
+	checkAttr(t, dst_ids, "k8s.daemonset.name", "mongo-ds")
+	checkAttr(t, dst_ids, k8sNamespace, "db")
+	checkAttr(t, dst_ids, swK8sClusterUid, testClusterUid)
+
+	checkAttr(t, relationAttrs[0], otelEntityRelationSourceType, discoveredDatabaseEntityType)
+	src_ids := getAttrMap(t, relationAttrs[0], otelEntityRelationSourceID)
+	checkAttr(t, src_ids, swDiscoveryDbAddress, "mongo-svc.db:27017")
+	checkAttr(t, src_ids, swDiscoveryDbType, "mongo")
 }
 
 func TestImageDiscovery_NonDefaultPortMatch(t *testing.T) {


### PR DESCRIPTION
#### Description
Inverted direction of the `DiscoveredBy` relation in the `swok8sdiscovery` receiver. Now it looks like `database -discoveredBy-> k8s workload`.

**Tracking Issue:** https://github.com/solarwinds/solarwinds-otel-collector-contrib/issues/146

#### Testing
Describe what testing was performed and which tests were added.

---

### Contribution Checklist

Please ensure your PR meets the following requirements (see [CONTRIBUTING.md](../CONTRIBUTING.md)):

**General:**
- [ ] **CHANGELOG updated** - Added entry under `## vNext` (chore PRs are a possible exemption)
- [ ] **Tests included** - Unit tests, generated tests (`mdatagen`), and/or integration tests
- [ ] **Documentation updated** - README.md with config examples and behavior description

**For new components:**
- [ ] **Codeowners** - Approver/maintainer assigned
- [ ] **Use case documented** - Reasoning, telemetry types, configuration options described in issue
- [ ] `mdatagen` has been used to autogenerate tests, update README.md and more (see [CONTRIBUTING.md](../CONTRIBUTING.md)):
- [ ] README.md contains complete configuration documentation
- [ ] **Telemetry names registered** - New metrics registered (if applicable)
> [!NOTE]  
> New components need to be added into the release (one or multiple distributions in our private releases repository).  
That can be done only after the new component has been merged & released.
