### PR TITLE
docs: clarify components are open-source in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SolarWinds OpenTelemetry Collector Contrib
-This repository contains components for [SolarWinds OpenTelemetry Collector](https://github.com/solarwinds/solarwinds-otel-collector-releases).
+This repository contains open-source components for the [SolarWinds OpenTelemetry Collector](https://github.com/solarwinds/solarwinds-otel-collector-releases).
 
 ## Contributing
 See [CONTRIBUTING.md](./CONTRIBUTING.md).


### PR DESCRIPTION
## Summary
Minor README wording — clarify the components are open-source. Docs-only, no functional change.

## Test plan
- [x] Docs-only; no build impact
