### PR TITLE
feature: #317 Extend processor `swootelentityref` with support for `description_keys`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## vNext
+- **Added** `swootelentityrefprocessor`: EntityRefs can now contain `description_keys`
 
 ## v0.152.8
 - No changes

--- a/processor/swootelentityrefprocessor/README.md
+++ b/processor/swootelentityrefprocessor/README.md
@@ -28,6 +28,8 @@ The `swootelentityref` processor inserts or removes [OpenTelemetry Entity Refere
 
 When `action: insert` is configured, the processor evaluates each `entity_refs` entry against the Resource attributes of every incoming signal (log record, metric resource, or trace resource). An EntityRef is appended to the Resource only when **all** attribute keys listed in `id_keys` are present. This means a single processor instance can hold a full static mapping (e.g. all Kubernetes entity types) and will only populate the entries that are actually supported by the attributes available on each resource.
 
+If a Resource already contains an EntityRef with a matching type, the processor leaves it untouched — it does not update `id_keys`, `description_keys`, or any other field on the existing ref.
+
 When `action: remove_all` is configured, all EntityRefs are cleared from the Resource of each signal.
 
 ## Configuration
@@ -38,6 +40,7 @@ When `action: remove_all` is configured, all EntityRefs are cleared from the Res
 | `entity_refs` | list | required when `action: insert` | List of EntityRef entries to evaluate. Must be empty when `action: remove_all`. Duplicate types (case-insensitive) are rejected at startup. |
 | `entity_refs[*].type` | string | ✅ | Entity type name (e.g. `KubernetesContainer`) |
 | `entity_refs[*].id_keys` | list of string | ✅ | Resource attribute keys that identify the entity; all must be present for the EntityRef to be inserted |
+| `entity_refs[*].description_keys` | list of string | ❌ | Resource attribute keys with additional entity information; only found keys are included in the EntityRef |
 
 ## Examples
 
@@ -52,6 +55,7 @@ processors:
     entity_refs:
       - type: KubernetesContainer
         id_keys: [sw.k8s.cluster.uid, k8s.namespace.name, k8s.pod.name, k8s.container.name]
+        description_keys: ["container.image.name"]
       - type: KubernetesPod
         id_keys: [sw.k8s.cluster.uid, k8s.namespace.name, k8s.pod.name]
       - type: KubernetesNode

--- a/processor/swootelentityrefprocessor/config.go
+++ b/processor/swootelentityrefprocessor/config.go
@@ -37,6 +37,11 @@ type EntityRefConfig struct {
 	// uniquely identify the entity. An EntityRef is only inserted when ALL
 	// listed keys are present in the Resource attributes.
 	IDKeys []string `mapstructure:"id_keys"`
+	// DescriptionKeys is the ordered list of Resource attribute keys that
+	// carry additional information for the entity. Only keys whose attributes
+	// are present (non-empty string) in the Resource are appended to the EntityRef;
+	// absent keys are silently skipped and do not prevent insertion.
+	DescriptionKeys []string `mapstructure:"description_keys"`
 
 	// normalizedType holds strings.ToLower(Type), pre-computed by Validate
 	// so processResource avoids per-signal allocations.
@@ -70,12 +75,14 @@ func (c *Config) Validate() error {
 		if len(er.IDKeys) == 0 {
 			return fmt.Errorf("entity_refs[%d]: id_keys must not be empty", i)
 		}
-		seenKeys := make(map[string]struct{}, len(er.IDKeys))
-		for _, k := range er.IDKeys {
-			if _, dup := seenKeys[k]; dup {
-				return fmt.Errorf("entity_refs[%d]: duplicate id_key %q", i, k)
-			}
-			seenKeys[k] = struct{}{}
+		if item, dup := c.findDuplicatedItem(er.IDKeys); dup {
+			return fmt.Errorf("entity_refs[%d]: duplicate id_key %q", i, item)
+		}
+		if item, dup := c.findDuplicatedItem(er.DescriptionKeys); dup {
+			return fmt.Errorf("entity_refs[%d]: duplicate description_key %q", i, item)
+		}
+		if item, overlap := c.findOverlappingItem(er.IDKeys, er.DescriptionKeys); overlap {
+			return fmt.Errorf("entity_refs[%d]: key %q appears in both id_keys and description_keys", i, item)
 		}
 		key := strings.ToLower(er.Type)
 		if prev, dup := seen[key]; dup {
@@ -85,4 +92,28 @@ func (c *Config) Validate() error {
 		er.normalizedType = key
 	}
 	return nil
+}
+
+func (c *Config) findDuplicatedItem(collection []string) (string, bool) {
+	seen := make(map[string]struct{}, len(collection))
+	for _, item := range collection {
+		if _, exists := seen[item]; exists {
+			return item, true
+		}
+		seen[item] = struct{}{}
+	}
+	return "", false
+}
+
+func (c *Config) findOverlappingItem(a, b []string) (string, bool) {
+	set := make(map[string]struct{}, len(a))
+	for _, item := range a {
+		set[item] = struct{}{}
+	}
+	for _, item := range b {
+		if _, exists := set[item]; exists {
+			return item, true
+		}
+	}
+	return "", false
 }

--- a/processor/swootelentityrefprocessor/config_test.go
+++ b/processor/swootelentityrefprocessor/config_test.go
@@ -137,3 +137,49 @@ func TestValidate_EntityRef_DuplicateIDKey(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "duplicate id_key")
 }
+
+func TestValidate_EntityRef_DuplicateDescriptionKey(t *testing.T) {
+	cfg := &Config{
+		Action: ActionInsert,
+		EntityRefs: []EntityRefConfig{
+			{
+				Type:            "KubernetesPod",
+				IDKeys:          []string{"sw.k8s.cluster.uid", "k8s.pod.name"},
+				DescriptionKeys: []string{"k8s.cluster.name", "k8s.cluster.name"},
+			},
+		},
+	}
+	err := cfg.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate description_key")
+}
+
+func TestValidate_EntityRef_DescriptionKeys_Valid(t *testing.T) {
+	cfg := &Config{
+		Action: ActionInsert,
+		EntityRefs: []EntityRefConfig{
+			{
+				Type:            "KubernetesPod",
+				IDKeys:          []string{"sw.k8s.cluster.uid", "k8s.pod.name"},
+				DescriptionKeys: []string{"k8s.cluster.name"},
+			},
+		},
+	}
+	require.NoError(t, cfg.Validate())
+}
+
+func TestValidate_EntityRef_KeyOverlapBetweenIDKeysAndDescriptionKeys(t *testing.T) {
+	cfg := &Config{
+		Action: ActionInsert,
+		EntityRefs: []EntityRefConfig{
+			{
+				Type:            "KubernetesPod",
+				IDKeys:          []string{"sw.k8s.cluster.uid", "k8s.pod.name"},
+				DescriptionKeys: []string{"k8s.cluster.name", "k8s.pod.name"},
+			},
+		},
+	}
+	err := cfg.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "appears in both id_keys and description_keys")
+}

--- a/processor/swootelentityrefprocessor/metadata.yaml
+++ b/processor/swootelentityrefprocessor/metadata.yaml
@@ -14,3 +14,4 @@ tests:
     entity_refs:
       - type: KubernetesPod
         id_keys: [sw.k8s.cluster.uid, k8s.namespace.name, k8s.pod.name]
+        description_keys: [k8s.cluster.name]

--- a/processor/swootelentityrefprocessor/processor.go
+++ b/processor/swootelentityrefprocessor/processor.go
@@ -89,7 +89,8 @@ func (p *swootelentityrefprocessor) processResource(resource pcommon.Resource) {
 		}
 		attrs := resource.Attributes()
 		for _, ercfg := range p.cfg.EntityRefs {
-			if !allKeysPresent(attrs, ercfg.IDKeys) {
+			// Only insert the EntityRef if all of its ID keys are present in the resource attributes.
+			if !p.allKeysPresent(attrs, ercfg.IDKeys) {
 				continue
 			}
 			if _, exists := existingTypes[ercfg.normalizedType]; exists {
@@ -98,11 +99,20 @@ func (p *swootelentityrefprocessor) processResource(resource pcommon.Resource) {
 			ref := refs.AppendEmpty()
 			ref.SetType(ercfg.Type)
 			idKeys := ref.IdKeys()
-			for _, k := range ercfg.IDKeys {
-				idKeys.Append(k)
-			}
+			idKeys.Append(ercfg.IDKeys...)
 			existingTypes[ercfg.normalizedType] = struct{}{}
-			p.logger.Debug("added entity ref", zap.String("type", ercfg.Type), zap.Any("idKeys", ercfg.IDKeys))
+
+			descKeys := ref.DescriptionKeys()
+			for _, k := range ercfg.DescriptionKeys {
+				// Only append description keys if they are present in the resource attributes.
+				if p.containsKey(attrs, k) {
+					descKeys.Append(k)
+				}
+			}
+
+			if ce := p.logger.Check(zap.DebugLevel, "added entity ref"); ce != nil {
+				ce.Write(zap.String("type", ercfg.Type), zap.Any("idKeys", ercfg.IDKeys), zap.Any("descriptionKeys", descKeys.AsRaw()))
+			}
 		}
 	case ActionRemoveAll:
 		// EntityRefSlice has no RemoveAll; RemoveIf with a tautological predicate is the standard clear pattern.
@@ -110,15 +120,16 @@ func (p *swootelentityrefprocessor) processResource(resource pcommon.Resource) {
 	}
 }
 
-func allKeysPresent(attrs pcommon.Map, keys []string) bool {
-	if len(keys) == 0 {
-		return false
-	}
+func (p *swootelentityrefprocessor) allKeysPresent(attrs pcommon.Map, keys []string) bool {
 	for _, k := range keys {
-		v, ok := attrs.Get(k)
-		if !ok || v.Type() != pcommon.ValueTypeStr || v.Str() == "" {
+		if !p.containsKey(attrs, k) {
 			return false
 		}
 	}
 	return true
+}
+
+func (p *swootelentityrefprocessor) containsKey(attrs pcommon.Map, key string) bool {
+	v, ok := attrs.Get(key)
+	return ok && v.Type() == pcommon.ValueTypeStr && v.Str() != ""
 }

--- a/processor/swootelentityrefprocessor/processor_test.go
+++ b/processor/swootelentityrefprocessor/processor_test.go
@@ -45,26 +45,30 @@ func buildTestProcessor(cfg component.Config) (*swootelentityrefprocessor, error
 
 // extractEntityRefs extracts the EntityRefs from a Resource into a plain slice for assertions.
 func extractEntityRefs(resource pcommon.Resource) []struct {
-	entityType string
-	idKeys     []string
+	entityType      string
+	idKeys          []string
+	descriptionKeys []string
 } {
 	refs := entity.ResourceEntityRefs(resource)
 	out := make([]struct {
-		entityType string
-		idKeys     []string
+		entityType      string
+		idKeys          []string
+		descriptionKeys []string
 	}, refs.Len())
 	for i, ref := range refs.All() {
 		out[i] = struct {
-			entityType string
-			idKeys     []string
-		}{entityType: ref.Type(), idKeys: ref.IdKeys().AsRaw()}
+			entityType      string
+			idKeys          []string
+			descriptionKeys []string
+		}{entityType: ref.Type(), idKeys: ref.IdKeys().AsRaw(), descriptionKeys: ref.DescriptionKeys().AsRaw()}
 	}
 	return out
 }
 
 func collectEntityRefs(ld plog.Logs) []struct {
-	entityType string
-	idKeys     []string
+	entityType      string
+	idKeys          []string
+	descriptionKeys []string
 } {
 	if ld.ResourceLogs().Len() == 0 {
 		return nil
@@ -395,6 +399,148 @@ func TestInsertLogs_NonStringAttribute(t *testing.T) {
 	assert.Empty(t, refs, "non-string id_key attribute must not produce an EntityRef")
 }
 
+// TestInsertLogs_DescriptionKeys_AllPresent: description_keys present in resource
+// attributes must all be appended to the inserted EntityRef.
+func TestInsertLogs_DescriptionKeys_AllPresent(t *testing.T) {
+	cfg := &Config{
+		Action: ActionInsert,
+		EntityRefs: []EntityRefConfig{
+			{
+				Type:            "KubernetesPod",
+				IDKeys:          []string{"sw.k8s.cluster.uid", "k8s.pod.name"},
+				DescriptionKeys: []string{"k8s.cluster.name", "k8s.namespace.name"},
+			},
+		},
+	}
+	ld := buildLogs(func(m pcommon.Map) {
+		m.PutStr("sw.k8s.cluster.uid", "cluster-1")
+		m.PutStr("k8s.pod.name", "my-pod")
+		m.PutStr("k8s.cluster.name", "my-cluster")
+		m.PutStr("k8s.namespace.name", "default")
+	})
+
+	p, err := buildTestProcessor(cfg)
+	require.NoError(t, err)
+	result, err := p.processLogs(context.Background(), ld)
+	require.NoError(t, err)
+
+	refs := collectEntityRefs(result)
+	require.Len(t, refs, 1)
+	assert.Equal(t, []string{"k8s.cluster.name", "k8s.namespace.name"}, refs[0].descriptionKeys)
+}
+
+// TestInsertLogs_DescriptionKeys_PartiallyPresent: only description_keys whose
+// attribute is present in the resource must be appended; missing ones are skipped.
+func TestInsertLogs_DescriptionKeys_PartiallyPresent(t *testing.T) {
+	cfg := &Config{
+		Action: ActionInsert,
+		EntityRefs: []EntityRefConfig{
+			{
+				Type:            "KubernetesPod",
+				IDKeys:          []string{"sw.k8s.cluster.uid", "k8s.pod.name"},
+				DescriptionKeys: []string{"k8s.cluster.name", "k8s.namespace.name"},
+			},
+		},
+	}
+	ld := buildLogs(func(m pcommon.Map) {
+		m.PutStr("sw.k8s.cluster.uid", "cluster-1")
+		m.PutStr("k8s.pod.name", "my-pod")
+		m.PutStr("k8s.cluster.name", "my-cluster")
+		// k8s.namespace.name intentionally absent
+	})
+
+	p, err := buildTestProcessor(cfg)
+	require.NoError(t, err)
+	result, err := p.processLogs(context.Background(), ld)
+	require.NoError(t, err)
+
+	refs := collectEntityRefs(result)
+	require.Len(t, refs, 1)
+	assert.Equal(t, []string{"k8s.cluster.name"}, refs[0].descriptionKeys)
+}
+
+// TestInsertLogs_DescriptionKeys_NoneConfigured: an EntityRefConfig without
+// DescriptionKeys must insert an EntityRef with no description keys.
+func TestInsertLogs_DescriptionKeys_NoneConfigured(t *testing.T) {
+	cfg := &Config{
+		Action: ActionInsert,
+		EntityRefs: []EntityRefConfig{
+			{Type: "KubernetesPod", IDKeys: []string{"sw.k8s.cluster.uid", "k8s.pod.name"}},
+		},
+	}
+	ld := buildLogs(func(m pcommon.Map) {
+		m.PutStr("sw.k8s.cluster.uid", "cluster-1")
+		m.PutStr("k8s.pod.name", "my-pod")
+	})
+
+	p, err := buildTestProcessor(cfg)
+	require.NoError(t, err)
+	result, err := p.processLogs(context.Background(), ld)
+	require.NoError(t, err)
+
+	refs := collectEntityRefs(result)
+	require.Len(t, refs, 1)
+	assert.Empty(t, refs[0].descriptionKeys)
+}
+
+// TestInsertLogs_DescriptionKeys_EmptyStringAttribute: a description_key attribute
+// present with an empty string value must not be appended.
+func TestInsertLogs_DescriptionKeys_EmptyStringAttribute(t *testing.T) {
+	cfg := &Config{
+		Action: ActionInsert,
+		EntityRefs: []EntityRefConfig{
+			{
+				Type:            "KubernetesPod",
+				IDKeys:          []string{"sw.k8s.cluster.uid", "k8s.pod.name"},
+				DescriptionKeys: []string{"k8s.cluster.name"},
+			},
+		},
+	}
+	ld := buildLogs(func(m pcommon.Map) {
+		m.PutStr("sw.k8s.cluster.uid", "cluster-1")
+		m.PutStr("k8s.pod.name", "my-pod")
+		m.PutStr("k8s.cluster.name", "") // present but empty
+	})
+
+	p, err := buildTestProcessor(cfg)
+	require.NoError(t, err)
+	result, err := p.processLogs(context.Background(), ld)
+	require.NoError(t, err)
+
+	refs := collectEntityRefs(result)
+	require.Len(t, refs, 1)
+	assert.Empty(t, refs[0].descriptionKeys)
+}
+
+// TestInsertLogs_DescriptionKeys_NonStringAttribute: a description_key attribute
+// present with a non-string value must not be appended to the EntityRef.
+func TestInsertLogs_DescriptionKeys_NonStringAttribute(t *testing.T) {
+	cfg := &Config{
+		Action: ActionInsert,
+		EntityRefs: []EntityRefConfig{
+			{
+				Type:            "KubernetesPod",
+				IDKeys:          []string{"sw.k8s.cluster.uid", "k8s.pod.name"},
+				DescriptionKeys: []string{"k8s.cluster.name"},
+			},
+		},
+	}
+	ld := buildLogs(func(m pcommon.Map) {
+		m.PutStr("sw.k8s.cluster.uid", "cluster-1")
+		m.PutStr("k8s.pod.name", "my-pod")
+		m.PutInt("k8s.cluster.name", 42) // non-string attribute
+	})
+
+	p, err := buildTestProcessor(cfg)
+	require.NoError(t, err)
+	result, err := p.processLogs(context.Background(), ld)
+	require.NoError(t, err)
+
+	refs := collectEntityRefs(result)
+	require.Len(t, refs, 1)
+	assert.Empty(t, refs[0].descriptionKeys, "non-string description_key attribute must not be appended")
+}
+
 // TestInsertLogs_ReadOnly: a read-only batch must return errReadOnlyBatch, not panic.
 func TestInsertLogs_ReadOnly(t *testing.T) {
 	cfg := &Config{
@@ -446,8 +592,9 @@ func buildMetrics(setAttrs func(pcommon.Map)) pmetric.Metrics {
 }
 
 func collectMetricEntityRefs(md pmetric.Metrics) []struct {
-	entityType string
-	idKeys     []string
+	entityType      string
+	idKeys          []string
+	descriptionKeys []string
 } {
 	if md.ResourceMetrics().Len() == 0 {
 		return nil
@@ -713,6 +860,34 @@ func TestInsertMetrics_Idempotent_CaseInsensitive(t *testing.T) {
 	assert.Equal(t, "KUBERNETESPOD", refs[0].entityType)
 }
 
+func TestInsertMetrics_DescriptionKeys_PartiallyPresent(t *testing.T) {
+	cfg := &Config{
+		Action: ActionInsert,
+		EntityRefs: []EntityRefConfig{
+			{
+				Type:            "KubernetesPod",
+				IDKeys:          []string{"sw.k8s.cluster.uid", "k8s.pod.name"},
+				DescriptionKeys: []string{"k8s.cluster.name", "k8s.namespace.name"},
+			},
+		},
+	}
+	md := buildMetrics(func(m pcommon.Map) {
+		m.PutStr("sw.k8s.cluster.uid", "cluster-1")
+		m.PutStr("k8s.pod.name", "my-pod")
+		m.PutStr("k8s.cluster.name", "my-cluster")
+		// k8s.namespace.name intentionally absent
+	})
+
+	p, err := buildTestProcessor(cfg)
+	require.NoError(t, err)
+	result, err := p.processMetrics(context.Background(), md)
+	require.NoError(t, err)
+
+	refs := collectMetricEntityRefs(result)
+	require.Len(t, refs, 1)
+	assert.Equal(t, []string{"k8s.cluster.name"}, refs[0].descriptionKeys)
+}
+
 // --- Traces helpers and tests ---
 
 func buildTraces(setAttrs func(pcommon.Map)) ptrace.Traces {
@@ -723,8 +898,9 @@ func buildTraces(setAttrs func(pcommon.Map)) ptrace.Traces {
 }
 
 func collectTraceEntityRefs(td ptrace.Traces) []struct {
-	entityType string
-	idKeys     []string
+	entityType      string
+	idKeys          []string
+	descriptionKeys []string
 } {
 	if td.ResourceSpans().Len() == 0 {
 		return nil
@@ -988,4 +1164,32 @@ func TestInsertTraces_Idempotent_CaseInsensitive(t *testing.T) {
 	refs := collectTraceEntityRefs(result)
 	require.Len(t, refs, 1, "case-insensitive duplicate must not be inserted")
 	assert.Equal(t, "KUBERNETESPOD", refs[0].entityType)
+}
+
+func TestInsertTraces_DescriptionKeys_PartiallyPresent(t *testing.T) {
+	cfg := &Config{
+		Action: ActionInsert,
+		EntityRefs: []EntityRefConfig{
+			{
+				Type:            "KubernetesPod",
+				IDKeys:          []string{"sw.k8s.cluster.uid", "k8s.pod.name"},
+				DescriptionKeys: []string{"k8s.cluster.name", "k8s.namespace.name"},
+			},
+		},
+	}
+	td := buildTraces(func(m pcommon.Map) {
+		m.PutStr("sw.k8s.cluster.uid", "cluster-1")
+		m.PutStr("k8s.pod.name", "my-pod")
+		m.PutStr("k8s.cluster.name", "my-cluster")
+		// k8s.namespace.name intentionally absent
+	})
+
+	p, err := buildTestProcessor(cfg)
+	require.NoError(t, err)
+	result, err := p.processTraces(context.Background(), td)
+	require.NoError(t, err)
+
+	refs := collectTraceEntityRefs(result)
+	require.Len(t, refs, 1)
+	assert.Equal(t, []string{"k8s.cluster.name"}, refs[0].descriptionKeys)
 }


### PR DESCRIPTION
#### Description
Add support for setting `description_keys` in EntityRef structure in the `swootelentityref` processor.

**Tracking Issue:** https://github.com/solarwinds/solarwinds-otel-collector-contrib/issues/317

#### Testing
Unit tests and manual test in k8s collector.

---

### Contribution Checklist

Please ensure your PR meets the following requirements (see [CONTRIBUTING.md](../CONTRIBUTING.md)):

**General:**
- [x] **CHANGELOG updated** - Added entry under `## vNext` (chore PRs are a possible exemption)
- [x] **Tests included** - Unit tests, generated tests (`mdatagen`), and/or integration tests
- [x] **Documentation updated** - README.md with config examples and behavior description

**For new components:**
- [ ] **Codeowners** - Approver/maintainer assigned
- [ ] **Use case documented** - Reasoning, telemetry types, configuration options described in issue
- [ ] `mdatagen` has been used to autogenerate tests, update README.md and more (see [CONTRIBUTING.md](../CONTRIBUTING.md)):
- [ ] README.md contains complete configuration documentation
- [ ] **Telemetry names registered** - New metrics registered (if applicable)
> [!NOTE]  
> New components need to be added into the release (one or multiple distributions in our private releases repository).  
That can be done only after the new component has been merged & released.
