### PR TITLE
feat(dnsqueryreceiver): accept tcp-tls as a network protocol (NH-134036)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
 ## vNext
+- **Added** `dnsqueryreceiver` accepts `tcp-tls` as a `network` value, enabling DNS over TLS queries. Reaches parity with the Telegraf `dns_query` input plugin, which also supports it. (NH-134036)
+- **Fixed** `dnsqueryreceiver` changelog entry for v0.152.6 listed metric names the receiver never emitted.
 
 ## v0.152.6
-- **Added** `dnsqueryreceiver` New OTel Collector receiver replacing the Telegraf `dns_query` input plugin. Emits `dns.query.duration_milliseconds`, `dns.query.result`, and `dns.query.response_time_ms` metrics. (NH-134035)
+- **Added** `dnsqueryreceiver` New OTel Collector receiver replacing the Telegraf `dns_query` input plugin. Emits `dns_query.query_time_ms`, `dns_query.rcode_value`, and `dns_query.result_code` metrics. (NH-134035)
 
 ## v0.152.5
 - No changes

--- a/receiver/dnsqueryreceiver/README.md
+++ b/receiver/dnsqueryreceiver/README.md
@@ -39,10 +39,11 @@ receivers:
     record_type: NS
 
     # Network protocol. Default: udp
-    # Allowed: udp, tcp
+    # Allowed: udp, tcp, tcp-tls
     network: udp
 
     # DNS server port. Default: 53
+    # DNS over TLS (network: tcp-tls) servers usually listen on 853.
     port: 53
 
     # Query timeout. Default: 2s
@@ -59,8 +60,18 @@ receivers:
 | `servers` | `[]string` | — | Yes | DNS servers to query. Each entry is an IP address or hostname. |
 | `domains` | `[]string` | `["."]` | No | Domains to resolve. The root domain `"."` queries for root NS records. |
 | `record_type` | `string` | `NS` | No | DNS record type to query. Allowed: `A`, `AAAA`, `ANY`, `CNAME`, `MX`, `NS`, `PTR`, `SOA`, `SPF`, `SRV`, `TXT`. |
-| `network` | `string` | `udp` | No | Transport protocol. Allowed: `udp`, `tcp`. |
+| `network` | `string` | `udp` | No | Transport protocol. Allowed: `udp`, `tcp`, `tcp-tls`. |
 | `port` | `int` | `53` | No | DNS server port. Must be between 1 and 65535. |
+
+### DNS over TLS
+
+Setting `network: tcp-tls` performs the query over DNS over TLS. Two things to be aware of:
+
+- **Port.** DoT resolvers listen on 853, while `port` defaults to 53 — set `port: 853` explicitly.
+- **Certificate validation.** TLS is negotiated with the default client configuration, which derives the
+  expected server name from the configured `servers` entry. Querying an IP address therefore requires the
+  resolver's certificate to carry a matching IP SAN; prefer the resolver's hostname (e.g. `dns.google`)
+  when it has one. There are no receiver-level TLS settings.
 | `timeout` | `duration` | `2s` | No | Per-query timeout. Must be a positive duration. |
 | `collection_interval` | `duration` | `60s` | No | How frequently to run the scrape cycle. |
 

--- a/receiver/dnsqueryreceiver/config.go
+++ b/receiver/dnsqueryreceiver/config.go
@@ -33,7 +33,7 @@ type Config struct {
 	Domains []string `mapstructure:"domains"`
 	// RecordType is the DNS record type to query. Default: "NS"
 	RecordType string `mapstructure:"record_type"`
-	// Network is the network protocol to use: "udp" or "tcp". Default: "udp"
+	// Network is the network protocol to use: "udp", "tcp" or "tcp-tls". Default: "udp"
 	Network string `mapstructure:"network"`
 	// Port is the DNS server port. Default: 53
 	Port int `mapstructure:"port"`
@@ -46,8 +46,12 @@ var allowedRecordTypes = map[string]bool{
 	"NS": true, "PTR": true, "SOA": true, "SPF": true, "SRV": true, "TXT": true,
 }
 
+// WARNING: "tcp-tls" (DNS over TLS) servers usually listen on port 853, not the
+// default 53 — the port must be set explicitly. TLS is negotiated with the default
+// client configuration, so the server certificate must be valid for the configured
+// server address.
 var allowedNetworks = map[string]bool{
-	"udp": true, "tcp": true,
+	"udp": true, "tcp": true, "tcp-tls": true,
 }
 
 // Validate checks the configuration for errors.
@@ -64,7 +68,7 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("record_type %q is not valid; allowed values: A, AAAA, ANY, CNAME, MX, NS, PTR, SOA, SPF, SRV, TXT", c.RecordType)
 	}
 	if !allowedNetworks[c.Network] {
-		return fmt.Errorf("network %q is not valid; allowed values: udp, tcp", c.Network)
+		return fmt.Errorf("network %q is not valid; allowed values: udp, tcp, tcp-tls", c.Network)
 	}
 	if c.Port < 1 || c.Port > 65535 {
 		return fmt.Errorf("port %d is not valid; must be between 1 and 65535", c.Port)

--- a/receiver/dnsqueryreceiver/config_test.go
+++ b/receiver/dnsqueryreceiver/config_test.go
@@ -93,6 +93,19 @@ func TestValidate_ValidMinimal(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestValidate_AllNetworks(t *testing.T) {
+	networks := []string{"udp", "tcp", "tcp-tls"}
+	for _, network := range networks {
+		t.Run(network, func(t *testing.T) {
+			cfg := defaultTestConfig()
+			cfg.Servers = []string{"8.8.8.8"}
+			cfg.Network = network
+			err := cfg.Validate()
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestValidate_AllRecordTypes(t *testing.T) {
 	recordTypes := []string{"A", "AAAA", "ANY", "CNAME", "MX", "NS", "PTR", "SOA", "SPF", "SRV", "TXT"}
 	for _, rt := range recordTypes {


### PR DESCRIPTION
## Summary

- Adds `tcp-tls` (DNS over TLS) as an accepted value for the `network` config field in `dnsqueryreceiver`
- The underlying `miekg/dns` library already supports it; only the `allowedNetworks` whitelist was blocking it
- Updates error message, README docs, and adds test coverage for the new value

## Motivation

Telegraf's `dns_query` plugin supports `tcp-tls`. This change brings the OTel receiver to full parity as part of the DNS Query Telegraf→OTel migration (NH-134037).

## Changes

- `config.go`: add `"tcp-tls"` to `allowedNetworks`; update error message to list all three allowed values
- `README.md`: document `tcp-tls` option and add a note that DoT servers typically listen on port 853
- `config_test.go`: add test case validating `tcp-tls` is accepted

## Test plan

- [ ] `go test ./receiver/dnsqueryreceiver/...` passes
- [ ] Manual: configure receiver with `network: tcp-tls`, verify it connects to a DoT server (e.g. `dns.google:853`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)