### PR TITLE
chore: bump Go to 1.26.6

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -14,7 +14,7 @@ on:
   workflow_call:
 
 env:
-  GO_VERSION: '1.26.5'
+  GO_VERSION: '1.26.6'
   SHARED_SCRIPTS: './submodules/solarwinds-otel-collector-core/build/scripts'
 
 jobs:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: "^1.26.5"
+          go-version: "^1.26.6"
 
       # for npx commands (CircleCI MCP may need this)
       - name: Set up Node.js

--- a/connector/solarwindsentityconnector/go.mod
+++ b/connector/solarwindsentityconnector/go.mod
@@ -1,6 +1,6 @@
 module github.com/solarwinds/solarwinds-otel-collector-contrib/connector/solarwindsentityconnector
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/dgraph-io/ristretto/v2 v2.4.2

--- a/extension/solarwindsextension/go.mod
+++ b/extension/solarwindsextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/solarwinds/solarwinds-otel-collector-contrib/extension/solarwindsextension
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/testutil v0.157.1

--- a/internal/k8sconfig/go.mod
+++ b/internal/k8sconfig/go.mod
@@ -1,6 +1,6 @@
 module github.com/solarwinds/solarwinds-otel-collector-contrib/internal/k8sconfig
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/openshift/client-go v0.0.0-20250513150353-9ea84fa6431b

--- a/pkg/attributesdecorator/go.mod
+++ b/pkg/attributesdecorator/go.mod
@@ -1,6 +1,6 @@
 module github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/attributesdecorator
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/pkg/container/go.mod
+++ b/pkg/container/go.mod
@@ -1,6 +1,6 @@
 module github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/container
 
-go 1.26.5
+go 1.26.6
 
 require (
 	go.uber.org/zap v1.28.0

--- a/pkg/extensionfinder/go.mod
+++ b/pkg/extensionfinder/go.mod
@@ -1,6 +1,6 @@
 module github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/extensionfinder
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/pkg/registry/go.mod
+++ b/pkg/registry/go.mod
@@ -1,5 +1,5 @@
 module github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/registry
 
-go 1.26.5
+go 1.26.6
 
 require golang.org/x/sys v0.47.0

--- a/pkg/testutil/go.mod
+++ b/pkg/testutil/go.mod
@@ -1,6 +1,6 @@
 module github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/testutil
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/pkg/version/go.mod
+++ b/pkg/version/go.mod
@@ -1,3 +1,3 @@
 module github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/version
 
-go 1.26.5
+go 1.26.6

--- a/pkg/wmi/go.mod
+++ b/pkg/wmi/go.mod
@@ -1,6 +1,6 @@
 module github.com/solarwinds/solarwinds-otel-collector-contrib/pkg/wmi
 
-go 1.26.5
+go 1.26.6
 
 require github.com/yusufpapurcu/wmi v1.2.4
 

--- a/processor/k8seventgenerationprocessor/go.mod
+++ b/processor/k8seventgenerationprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/solarwinds/solarwinds-otel-collector-contrib/processor/k8seventgenerationprocessor
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/google/go-containerregistry v0.21.9

--- a/processor/solarwindsprocessor/go.mod
+++ b/processor/solarwindsprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/solarwinds/solarwinds-otel-collector-contrib/processor/solarwindsprocessor
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/processor/swok8sworkloadstatusprocessor/go.mod
+++ b/processor/swok8sworkloadstatusprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/solarwinds/solarwinds-otel-collector-contrib/processor/swok8sworkloadstatusprocessor
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/processor/swok8sworkloadtypeprocessor/go.mod
+++ b/processor/swok8sworkloadtypeprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/solarwinds/solarwinds-otel-collector-contrib/processor/swok8sworkloadtypeprocessor
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/solarwinds/solarwinds-otel-collector-contrib/internal/k8sconfig v0.157.1

--- a/processor/swootelentityrefprocessor/go.mod
+++ b/processor/swootelentityrefprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/solarwinds/solarwinds-otel-collector-contrib/processor/swootelentityrefprocessor
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/receiver/dnsqueryreceiver/go.mod
+++ b/receiver/dnsqueryreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/solarwinds/solarwinds-otel-collector-contrib/receiver/dnsqueryreceiver
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/mqttreceiver/go.mod
+++ b/receiver/mqttreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/solarwinds/solarwinds-otel-collector-contrib/receiver/mqttreceiver
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/eclipse/paho.mqtt.golang v1.5.1

--- a/receiver/swohostmetricsreceiver/go.mod
+++ b/receiver/swohostmetricsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/solarwinds/solarwinds-otel-collector-contrib/receiver/swohostmetricsreceiver
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/go-ole/go-ole v1.3.0

--- a/receiver/swok8sdiscovery/go.mod
+++ b/receiver/swok8sdiscovery/go.mod
@@ -1,6 +1,6 @@
 module github.com/solarwinds/solarwinds-otel-collector-contrib/receiver/swok8sdiscovery
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/solarwinds/solarwinds-otel-collector-contrib/internal/k8sconfig v0.157.1

--- a/receiver/swok8sobjectsreceiver/go.mod
+++ b/receiver/swok8sobjectsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/solarwinds/solarwinds-otel-collector-contrib/receiver/swok8sobjectsreceiver
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
Bumps Go to 1.26.6 and advances the core submodule.

- `go 1.26.5` → `go 1.26.6` across all 20 `go.mod` modules
- `submodules/solarwinds-otel-collector-core` → latest main (`87116e5`)