### PR TITLE
docs: add CHANGELOG entry for Go 1.26.6 bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## vNext
+- Updates golang to 1.26.6
 
 ## v0.157.1
 - No changes


### PR DESCRIPTION
Adds the missing CHANGELOG `vNext` entry for the Go 1.26.6 bump (the bump PR #366 merged without it).