### PR TITLE
chore: Emit distribution attribute in resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## vNext
+- **Added** `solarwindsextension`: emits `sw.otelcol.collector.distribution` resource attribute on the `sw.otelcol.uptime` heartbeat metric, derived from the collector binary name by stripping the `solarwinds-otel-collector-` prefix
 
 ## v0.157.1
 - No changes

--- a/extension/solarwindsextension/internal/heartbeat.go
+++ b/extension/solarwindsextension/internal/heartbeat.go
@@ -17,6 +17,7 @@ package internal
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"time"
 
@@ -30,11 +31,13 @@ import (
 )
 
 const (
-	defaultHeartbeatInterval  = 30 * time.Second
-	CollectorNameAttribute    = "sw.otelcol.collector.name"
-	CollectorVersionAttribute = "sw.otelcol.collector.version"
-	EntityCreation            = "sw.otelcol.collector.entity_creation"
-	EntityCreationValue       = "on"
+	defaultHeartbeatInterval       = 30 * time.Second
+	CollectorNameAttribute         = "sw.otelcol.collector.name"
+	CollectorVersionAttribute      = "sw.otelcol.collector.version"
+	CollectorDistributionAttribute = "sw.otelcol.collector.distribution"
+	EntityCreation                 = "sw.otelcol.collector.entity_creation"
+	EntityCreationValue            = "on"
+	collectorCommandPrefix         = "solarwinds-otel-collector-"
 )
 
 type Heartbeat struct {
@@ -46,6 +49,7 @@ type Heartbeat struct {
 	metric        *UptimeMetric
 	exporter      exporter.Metrics
 	collectorName string
+	distribution  string
 	withoutEntity bool
 
 	beatInterval time.Duration
@@ -74,11 +78,23 @@ func newHeartbeatWithExporter(
 		logger:        set.Logger,
 		metric:        newUptimeMetric(set.Logger),
 		collectorName: cfg.CollectorName,
+		distribution:  distributionFromCommand(set.BuildInfo.Command),
 		exporter:      exporter,
 		beatInterval:  defaultHeartbeatInterval,
 		resource:      cfg.Resource,
 		withoutEntity: cfg.WithoutEntity,
 	}
+}
+
+// distributionFromCommand derives the distribution name by stripping the
+// well-known solarwinds-otel-collector- prefix from the collector binary
+// command. Returns an empty string when the command does not carry the prefix,
+// meaning no distribution attribute should be emitted for custom builds.
+func distributionFromCommand(command string) string {
+	if !strings.HasPrefix(command, collectorCommandPrefix) {
+		return ""
+	}
+	return strings.TrimPrefix(command, collectorCommandPrefix)
 }
 
 func (h *Heartbeat) Start(ctx context.Context, host component.Host) error {
@@ -169,5 +185,8 @@ func (h *Heartbeat) decorateResourceAttributes(resource pcommon.Resource) error 
 		resource.Attributes().PutStr(EntityCreation, EntityCreationValue)
 	}
 	resource.Attributes().PutStr(CollectorVersionAttribute, version.Version)
+	if h.distribution != "" {
+		resource.Attributes().PutStr(CollectorDistributionAttribute, h.distribution)
+	}
 	return nil
 }

--- a/extension/solarwindsextension/internal/hearthbeat_test.go
+++ b/extension/solarwindsextension/internal/hearthbeat_test.go
@@ -16,18 +16,16 @@ package internal
 
 import (
 	"context"
-
-	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/consumer"
-	"go.opentelemetry.io/collector/exporter"
-
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/extension/extensiontest"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
@@ -112,4 +110,94 @@ func TestHeartbeatEmittingMetrics(t *testing.T) {
 
 	err = hb.Shutdown(ctx)
 	require.NoError(t, err)
+}
+
+func TestDistributionAttributeDerivation(t *testing.T) {
+	tests := []struct {
+		command  string
+		expected string
+	}{
+		{command: "solarwinds-otel-collector-verified", expected: "verified"},
+		{command: "solarwinds-otel-collector-k8s", expected: "k8s"},
+		{command: "solarwinds-otel-collector-playground", expected: "playground"},
+		// Unknown or custom commands do not carry the well-known prefix: no
+		// distribution attribute should be emitted, so distribution is empty.
+		{command: "my-custom-collector", expected: ""},
+		{command: "", expected: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.command, func(t *testing.T) {
+			set := extensiontest.NewNopSettings(extensiontest.NopType)
+			set.BuildInfo = component.BuildInfo{Command: tc.command}
+
+			hb := newHeartbeatWithExporter(set, &Config{WithoutEntity: true}, newMockExporter())
+			assert.Equal(t, tc.expected, hb.distribution)
+		})
+	}
+}
+
+func TestDistributionAttributeNotEmittedForUnknownCommand(t *testing.T) {
+	set := extensiontest.NewNopSettings(extensiontest.NopType)
+	set.BuildInfo = component.BuildInfo{Command: "my-custom-collector"}
+
+	mockExp := newMockExporter()
+	hb := newHeartbeatWithExporter(set, &Config{WithoutEntity: true}, mockExp)
+
+	ctx := t.Context()
+	err := hb.Start(ctx, componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	assert.Eventuallyf(
+		t,
+		func() bool { return mockExp.pushedLen() >= 1 },
+		500*time.Millisecond,
+		10*time.Millisecond,
+		"expected at least one heartbeat",
+	)
+
+	err = hb.Shutdown(ctx)
+	require.NoError(t, err)
+
+	mockExp.mPushed.Lock()
+	defer mockExp.mPushed.Unlock()
+	require.NotEmpty(t, mockExp.pushed)
+
+	attrs := mockExp.pushed[0].ResourceMetrics().At(0).Resource().Attributes()
+	_, ok := attrs.Get(CollectorDistributionAttribute)
+	assert.False(t, ok, "distribution attribute must not be emitted for unknown command")
+}
+
+func TestDistributionAttributeEmitted(t *testing.T) {
+	set := extensiontest.NewNopSettings(extensiontest.NopType)
+	set.BuildInfo = component.BuildInfo{Command: "solarwinds-otel-collector-verified"}
+
+	mockExp := newMockExporter()
+	hb := newHeartbeatWithExporter(set, &Config{WithoutEntity: true}, mockExp)
+
+	ctx := t.Context()
+	err := hb.Start(ctx, componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	assert.Eventuallyf(
+		t,
+		func() bool { return mockExp.pushedLen() >= 1 },
+		500*time.Millisecond,
+		10*time.Millisecond,
+		"expected at least one heartbeat",
+	)
+
+	err = hb.Shutdown(ctx)
+	require.NoError(t, err)
+
+	mockExp.mPushed.Lock()
+	defer mockExp.mPushed.Unlock()
+	require.NotEmpty(t, mockExp.pushed)
+
+	rms := mockExp.pushed[0].ResourceMetrics()
+	require.Equal(t, 1, rms.Len())
+	attrs := rms.At(0).Resource().Attributes()
+	val, ok := attrs.Get(CollectorDistributionAttribute)
+	require.True(t, ok, "attribute %s must be present", CollectorDistributionAttribute)
+	assert.Equal(t, "verified", val.Str())
 }


### PR DESCRIPTION
## Summary

The `solarwindsextension` now emits a `sw.otelcol.collector.distribution` resource attribute on the heartbeat resource, identifying which named SolarWinds distribution the collector was built from (e.g. `verified`, `k8s`, `playground`, `nio`).

- Derives the distribution name from `BuildInfo.Command` by stripping the well-known `solarwinds-otel-collector-` prefix (the OTel Collector Builder sets `Command` to the distribution's `dist.name`, e.g. `solarwinds-otel-collector-verified` → `verified`)
- Adds the attribute to the heartbeat resource alongside the existing `sw.otelcol.collector.version` and `sw.otelcol.collector.name` attributes
- Backward-compatible: when `BuildInfo.Command` does not carry the prefix (custom builds), the distribution is empty and the attribute is omitted

## Testing

- Unit tests added / updated in `extension/solarwindsextension/`
  - `TestDistributionAttributeDerivation` — prefix stripping across known, custom, and empty commands
  - `TestDistributionAttributeEmitted` — attribute present for a known distribution
  - `TestDistributionAttributeNotEmittedForUnknownCommand` — attribute omitted for custom builds
- `go test ./extension/solarwindsextension/...` passes
